### PR TITLE
fix: ajout vercel.json pour le routing SPA

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Les routes côté client (ex: /signin) retournaient une 404 sur Vercel car le serveur ne savait pas rediriger vers index.html.