### PR TITLE
fix(configurator): verrouille l'ordre de sélection et corrige les imp…

### DIFF
--- a/src/pages/Configurator/Configurator.scss
+++ b/src/pages/Configurator/Configurator.scss
@@ -306,6 +306,23 @@
     background: rgba(245, 158, 11, 0.06);
     color: var(--warn);
   }
+
+  &--locked {
+    border-color: rgba(99, 102, 241, 0.25);
+    background: rgba(99, 102, 241, 0.06);
+    color: var(--ind);
+  }
+}
+
+.config-item--locked,
+.config-tab--locked {
+  opacity: 0.5;
+  cursor: not-allowed;
+
+  &:hover {
+    background: inherit;
+    border-color: var(--border);
+  }
 }
 
 .config-search {

--- a/src/pages/Configurator/Configurator.tsx
+++ b/src/pages/Configurator/Configurator.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { supabase } from '../../config'
-import { useConfigStore } from '../../store'
+import { useConfigStore, useToast } from '../../store'
 import { CATEGORIES } from '../../types'
 import { KEY_SPECS, SPEC_LABELS, SPEC_UNITS } from '../../constants'
 import type { Product, CategoryKey } from '../../types'
-import { getCompatibleProductIds } from '../../utils'
+import { getCompatibleProductIds, missingPrereqs, nextPendingCategory, SELECTION_ORDER } from '../../utils'
 import './Configurator.scss'
 
 const PAGE_SIZE = 24
@@ -19,8 +19,13 @@ function renderSpecValue(val: unknown, unit?: string): string {
   return unit ? `${str} ${unit}` : str
 }
 
+function categoryLabel(cat: CategoryKey): string {
+  return CATEGORIES.find((c) => c.value === cat)?.label ?? cat
+}
+
 function Configurator() {
-  const { config, selectComponent, removeComponent, clearConfig } = useConfigStore()
+  const { config, lastInvalidated, selectComponent, removeComponent, clearInvalidated, clearConfig } = useConfigStore()
+  const toast = useToast()
 
   const [activeCategory, setActiveCategory] = useState<CategoryKey>('cpu')
   const [products, setProducts] = useState<Product[]>([])
@@ -32,8 +37,25 @@ function Configurator() {
 
   const cpuId = config['cpu']?.id
   const motherboardId = config['motherboard']?.id
+  const pcCaseId = config['pc_case']?.id
+  const gpuId = config['gpu']?.id
+
+  const missingForActive = useMemo(
+    () => missingPrereqs(activeCategory, config),
+    [activeCategory, config],
+  )
+  const locked = missingForActive.length > 0
 
   useEffect(() => {
+    if (lastInvalidated.length === 0) return
+    const labels = lastInvalidated.map(categoryLabel).join(', ')
+    toast.warning(`Sélections incompatibles retirées : ${labels}`)
+    clearInvalidated()
+  }, [lastInvalidated, toast, clearInvalidated])
+
+  useEffect(() => {
+    if (locked) return
+
     let cancelled = false
     const categoryDef = CATEGORIES.find((c) => c.value === activeCategory)!
     const from = page * PAGE_SIZE
@@ -102,7 +124,7 @@ function Configurator() {
           productsData.map((p) => ({
             ...p,
             specs: specsMap.get(p.id) || null,
-          }))
+          })),
         )
         setLoading(false)
       }
@@ -110,12 +132,31 @@ function Configurator() {
 
     void run()
     return () => { cancelled = true }
-  }, [activeCategory, page, search, cpuId, motherboardId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activeCategory, page, search, cpuId, motherboardId, pcCaseId, gpuId, locked]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleCategoryChange = (cat: CategoryKey) => {
+    const missing = missingPrereqs(cat, config)
+    if (missing.length > 0) {
+      const first = missing[0]
+      toast.info(`Sélectionne d'abord ${categoryLabel(first)}`)
+      setActiveCategory(first)
+      setSearch('')
+      setPage(0)
+      return
+    }
     setActiveCategory(cat)
     setSearch('')
     setPage(0)
+  }
+
+  const handleSelect = (cat: CategoryKey, product: Product) => {
+    selectComponent(cat, product)
+    const next = nextPendingCategory({ ...config, [cat]: product })
+    if (next && next !== cat) {
+      setActiveCategory(next)
+      setSearch('')
+      setPage(0)
+    }
   }
 
   const selectedCount = Object.keys(config).length
@@ -124,7 +165,9 @@ function Configurator() {
 
   const totalAvg = Object.values(config).reduce((acc, p) => acc + (p?.price_avg_eur ?? 0), 0)
 
-  const activeCatDef = CATEGORIES.find(c => c.value === activeCategory)!
+  const activeCatDef = CATEGORIES.find((c) => c.value === activeCategory)!
+
+  const orderedCategories = SELECTION_ORDER.map((key) => CATEGORIES.find((c) => c.value === key)!).filter(Boolean)
 
   return (
     <div className="config-wrap">
@@ -140,22 +183,27 @@ function Configurator() {
         </div>
 
         <div className="config-items">
-          {CATEGORIES.map((cat, idx) => {
+          {orderedCategories.map((cat, idx) => {
             const selected = config[cat.value]
             const isActive = activeCategory === cat.value
+            const catLocked = missingPrereqs(cat.value, config).length > 0
             return (
               <button
                 key={cat.value}
                 type="button"
-                className={`config-item ${isActive ? 'config-item--act' : ''}`}
+                className={`config-item ${isActive ? 'config-item--act' : ''} ${catLocked ? 'config-item--locked' : ''}`}
                 onClick={() => handleCategoryChange(cat.value)}
+                aria-disabled={catLocked}
+                title={catLocked ? `Sélectionne d'abord ${categoryLabel(missingPrereqs(cat.value, config)[0])}` : undefined}
               >
                 <span className="config-item__n">{String(idx + 1).padStart(2, '0')}</span>
-                <span className="config-item__ico">{cat.icon}</span>
+                <span className="config-item__ico">{catLocked ? '🔒' : cat.icon}</span>
                 <div className="config-item__info">
                   <div className="config-item__lbl">{cat.label}</div>
                   {selected ? (
                     <div className="config-item__name">{selected.name}</div>
+                  ) : catLocked ? (
+                    <div className="config-item__empty">Verrouillé</div>
                   ) : (
                     <div className="config-item__empty">Non sélectionné</div>
                   )}
@@ -202,22 +250,25 @@ function Configurator() {
         <div className="config-main__hd">
           <h1 className="config-main__h1">Configurateur PC</h1>
           <p className="config-main__sub">
-            Explorez {CATEGORIES.length} catégories, ajoutez des composants compatibles, obtenez une config complète.
+            Sélectionne les composants dans l'ordre indiqué. La compatibilité est vérifiée à chaque étape.
           </p>
         </div>
 
         <div className="config-tabs">
-          {CATEGORIES.map((cat) => {
+          {orderedCategories.map((cat) => {
             const done = Boolean(config[cat.value])
             const act = activeCategory === cat.value
+            const catLocked = missingPrereqs(cat.value, config).length > 0
             return (
               <button
                 key={cat.value}
                 type="button"
-                className={`config-tab ${act ? 'config-tab--act' : ''}`}
+                className={`config-tab ${act ? 'config-tab--act' : ''} ${catLocked ? 'config-tab--locked' : ''}`}
                 onClick={() => handleCategoryChange(cat.value)}
+                aria-disabled={catLocked}
+                title={catLocked ? `Sélectionne d'abord ${categoryLabel(missingPrereqs(cat.value, config)[0])}` : undefined}
               >
-                <span>{cat.icon}</span>
+                <span>{catLocked ? '🔒' : cat.icon}</span>
                 <span>{cat.label}</span>
                 {done && <span className="config-tab__ck">✓</span>}
               </button>
@@ -225,151 +276,159 @@ function Configurator() {
           })}
         </div>
 
-        {compatInfo.active && (
-          <div className={`compat-info ${compatInfo.empty ? 'compat-info--empty' : ''}`}>
-            {compatInfo.empty
-              ? <>⚠️ Aucun composant compatible avec {compatInfo.reason}</>
-              : <>✓ Filtré pour compatibilité · {compatInfo.reason}</>}
+        {locked ? (
+          <div className="compat-info compat-info--locked">
+            🔒 Sélectionne d'abord {missingForActive.map(categoryLabel).join(', ')} pour débloquer {activeCatDef.label.toLowerCase()}
           </div>
-        )}
-
-        {!compatInfo.empty && (
-          <div className="config-search">
-            <span className="config-search__ico">⌕</span>
-            <input
-              type="text"
-              className="config-search__in"
-              placeholder={`Rechercher un ${activeCatDef.label.toLowerCase()}...`}
-              value={search}
-              onChange={(e) => { setSearch(e.target.value); setPage(0) }}
-            />
-            {totalCount > 0 && (
-              <span className="config-search__cnt">{totalCount} résultats</span>
-            )}
-          </div>
-        )}
-
-        {loading ? (
-          <div className="st-load">Chargement...</div>
-        ) : compatInfo.empty ? null : products.length === 0 ? (
-          <div className="st-empty">Aucun résultat.</div>
         ) : (
-          <div className="prod-grid">
-            {products.map((product, idx) => {
-              const isSelected = config[activeCategory]?.id === product.id
-              const keySpecs = KEY_SPECS[activeCategory] ?? []
+          <>
+            {compatInfo.active && (
+              <div className={`compat-info ${compatInfo.empty ? 'compat-info--empty' : ''}`}>
+                {compatInfo.empty
+                  ? <>⚠️ Aucun composant compatible avec {compatInfo.reason}</>
+                  : <>✓ Filtré pour compatibilité · {compatInfo.reason}</>}
+              </div>
+            )}
 
-              return (
-                <div
-                  key={product.id}
-                  className={`prod-card ${isSelected ? 'prod-card--sel' : ''}`}
-                >
-                  <div className="prod-card__img">
-                    <span className="prod-card__idx">#{String(page * PAGE_SIZE + idx + 1).padStart(3, '0')}</span>
-                    {isSelected && <span className="prod-card__sel-tag">Sélectionné</span>}
-                    {product.image_url ? (
-                      <img src={product.image_url} alt={product.name} />
-                    ) : (
-                      <span>{activeCatDef.icon}</span>
-                    )}
-                  </div>
+            {!compatInfo.empty && (
+              <div className="config-search">
+                <span className="config-search__ico">⌕</span>
+                <input
+                  type="text"
+                  className="config-search__in"
+                  placeholder={`Rechercher un ${activeCatDef.label.toLowerCase()}...`}
+                  value={search}
+                  onChange={(e) => { setSearch(e.target.value); setPage(0) }}
+                />
+                {totalCount > 0 && (
+                  <span className="config-search__cnt">{totalCount} résultats</span>
+                )}
+              </div>
+            )}
 
-                  <div className="prod-card__body">
-                    <div className="prod-card__name">{product.name}</div>
-                    <div className="prod-card__meta">
-                      {[product.manufacturer, product.series, product.release_year].filter(Boolean).join(' · ')}
-                    </div>
+            {loading ? (
+              <div className="st-load">Chargement...</div>
+            ) : compatInfo.empty ? null : products.length === 0 ? (
+              <div className="st-empty">Aucun résultat.</div>
+            ) : (
+              <div className="prod-grid">
+                {products.map((product, idx) => {
+                  const isSelected = config[activeCategory]?.id === product.id
+                  const keySpecs = KEY_SPECS[activeCategory] ?? []
 
-                    {product.specs && keySpecs.length > 0 && (
-                      <div className="prod-card__specs">
-                        {keySpecs
-                          .filter((key) => product.specs![key] !== null && product.specs![key] !== undefined)
-                          .slice(0, 3)
-                          .map((key) => (
-                            <div key={key} className="prod-card__spec">
-                              <span className="prod-card__sk">{SPEC_LABELS[key] ?? key.replace(/_/g, ' ')}</span>
-                              <span className="prod-card__sv">
-                                {renderSpecValue(product.specs![key], SPEC_UNITS[key])}
-                              </span>
-                            </div>
-                          ))}
+                  return (
+                    <div
+                      key={product.id}
+                      className={`prod-card ${isSelected ? 'prod-card--sel' : ''}`}
+                    >
+                      <div className="prod-card__img">
+                        <span className="prod-card__idx">#{String(page * PAGE_SIZE + idx + 1).padStart(3, '0')}</span>
+                        {isSelected && <span className="prod-card__sel-tag">Sélectionné</span>}
+                        {product.image_url ? (
+                          <img src={product.image_url} alt={product.name} />
+                        ) : (
+                          <span>{activeCatDef.icon}</span>
+                        )}
                       </div>
-                    )}
 
-                    {product.benchmark_score !== null && (
-                      <div className="prod-card__bench">
-                        <span className="prod-card__bench-l">Bench</span>
-                        <span className="prod-card__bench-v">{product.benchmark_score}</span>
+                      <div className="prod-card__body">
+                        <div className="prod-card__name">{product.name}</div>
+                        <div className="prod-card__meta">
+                          {[product.manufacturer, product.series, product.release_year].filter(Boolean).join(' · ')}
+                        </div>
+
+                        {product.specs && keySpecs.length > 0 && (
+                          <div className="prod-card__specs">
+                            {keySpecs
+                              .filter((key) => product.specs![key] !== null && product.specs![key] !== undefined)
+                              .slice(0, 3)
+                              .map((key) => (
+                                <div key={key} className="prod-card__spec">
+                                  <span className="prod-card__sk">{SPEC_LABELS[key] ?? key.replace(/_/g, ' ')}</span>
+                                  <span className="prod-card__sv">
+                                    {renderSpecValue(product.specs![key], SPEC_UNITS[key])}
+                                  </span>
+                                </div>
+                              ))}
+                          </div>
+                        )}
+
+                        {product.benchmark_score !== null && (
+                          <div className="prod-card__bench">
+                            <span className="prod-card__bench-l">Bench</span>
+                            <span className="prod-card__bench-v">{product.benchmark_score}</span>
+                          </div>
+                        )}
                       </div>
-                    )}
-                  </div>
 
-                  <div className="prod-card__ft">
-                    <div className="prod-card__price">
-                      {product.price_avg_eur !== null ? (
-                        <>
-                          <div className="prod-card__pr">~ {Math.round(product.price_avg_eur)} €</div>
-                          {product.price_min_eur !== null && product.price_max_eur !== null && (
-                            <div className="prod-card__pa">
-                              {Math.round(product.price_min_eur)}€ – {Math.round(product.price_max_eur)}€
-                            </div>
+                      <div className="prod-card__ft">
+                        <div className="prod-card__price">
+                          {product.price_avg_eur !== null ? (
+                            <>
+                              <div className="prod-card__pr">~ {Math.round(product.price_avg_eur)} €</div>
+                              {product.price_min_eur !== null && product.price_max_eur !== null && (
+                                <div className="prod-card__pa">
+                                  {Math.round(product.price_min_eur)}€ – {Math.round(product.price_max_eur)}€
+                                </div>
+                              )}
+                            </>
+                          ) : (
+                            <div className="prod-card__pa">Prix non disponible</div>
                           )}
-                        </>
-                      ) : (
-                        <div className="prod-card__pa">Prix non disponible</div>
-                      )}
+                        </div>
+
+                        {isSelected ? (
+                          <button
+                            type="button"
+                            className="btn btn--ok btn--full"
+                            onClick={() => removeComponent(activeCategory)}
+                          >
+                            ✓ Sélectionné
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn--ind btn--full"
+                            onClick={() => handleSelect(activeCategory, product)}
+                          >
+                            Sélectionner
+                          </button>
+                        )}
+
+                        <Link to={`/produit/${product.id}`} className="prod-detail-link">
+                          Voir la fiche →
+                        </Link>
+                      </div>
                     </div>
+                  )
+                })}
+              </div>
+            )}
 
-                    {isSelected ? (
-                      <button
-                        type="button"
-                        className="btn btn--ok btn--full"
-                        onClick={() => removeComponent(activeCategory)}
-                      >
-                        ✓ Sélectionné
-                      </button>
-                    ) : (
-                      <button
-                        type="button"
-                        className="btn btn--ind btn--full"
-                        onClick={() => selectComponent(activeCategory, product)}
-                      >
-                        Sélectionner
-                      </button>
-                    )}
-
-                    <Link to={`/produit/${product.id}`} className="prod-detail-link">
-                      Voir la fiche →
-                    </Link>
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-        )}
-
-        {totalPages > 1 && !compatInfo.empty && (
-          <div className="pagination">
-            <button
-              type="button"
-              className="btn btn--ghost2"
-              disabled={page === 0}
-              onClick={() => setPage(p => p - 1)}
-            >
-              ← Précédent
-            </button>
-            <span className="pagination__info">
-              Page {page + 1} / {totalPages}
-            </span>
-            <button
-              type="button"
-              className="btn btn--ghost2"
-              disabled={page >= totalPages - 1}
-              onClick={() => setPage(p => p + 1)}
-            >
-              Suivant →
-            </button>
-          </div>
+            {totalPages > 1 && !compatInfo.empty && (
+              <div className="pagination">
+                <button
+                  type="button"
+                  className="btn btn--ghost2"
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  ← Précédent
+                </button>
+                <span className="pagination__info">
+                  Page {page + 1} / {totalPages}
+                </span>
+                <button
+                  type="button"
+                  className="btn btn--ghost2"
+                  disabled={page >= totalPages - 1}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Suivant →
+                </button>
+              </div>
+            )}
+          </>
         )}
       </main>
     </div>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,14 +1,18 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { CategoryKey, Product } from '../types'
+import { cascadeInvalidations } from '../utils/selection-order'
 
 export { useToast, useToastStore } from './toastStore'
 export type { ToastVariant, Toast } from './toastStore'
 
 interface ConfigStore {
   config: Partial<Record<CategoryKey, Product>>
+  /** Dernière cascade d'invalidation (catégories retirées automatiquement). */
+  lastInvalidated: CategoryKey[]
   selectComponent: (category: CategoryKey, product: Product) => void
   removeComponent: (category: CategoryKey) => void
+  clearInvalidated: () => void
   clearConfig: () => void
 }
 
@@ -16,16 +20,28 @@ export const useConfigStore = create<ConfigStore>()(
   persist(
     (set) => ({
       config: {},
+      lastInvalidated: [],
       selectComponent: (category, product) =>
-        set((state) => ({ config: { ...state.config, [category]: product } })),
+        set((state) => {
+          const next: Partial<Record<CategoryKey, Product>> = { ...state.config, [category]: product }
+          const invalidated = cascadeInvalidations(category, next)
+          for (const cat of invalidated) delete next[cat]
+          return { config: next, lastInvalidated: invalidated }
+        }),
       removeComponent: (category) =>
         set((state) => {
           const next = { ...state.config }
           delete next[category]
-          return { config: next }
+          const invalidated = cascadeInvalidations(category, next)
+          for (const cat of invalidated) delete next[cat]
+          return { config: next, lastInvalidated: invalidated }
         }),
-      clearConfig: () => set({ config: {} }),
+      clearInvalidated: () => set({ lastInvalidated: [] }),
+      clearConfig: () => set({ config: {}, lastInvalidated: [] }),
     }),
-    { name: 'pc-aeris-config' }
-  )
+    {
+      name: 'pc-aeris-config',
+      partialize: (state) => ({ config: state.config }),
+    },
+  ),
 )

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -34,15 +34,17 @@ export interface Category {
   icon: string
 }
 
+// Ordre fixe d'assemblage : CPU → MOBO → boîtier → RAM → GPU → stockage → ventirad → PSU.
+// Cf. src/utils/selection-order.ts pour les pré-requis et la cascade d'invalidation.
 export const CATEGORIES: Category[] = [
   { value: 'cpu',         label: 'Processeur',      specsTable: 'cpu_specs',         icon: '🖥️' },
-  { value: 'motherboard', label: 'Carte mère',       specsTable: 'motherboard_specs', icon: '🔌' },
-  { value: 'ram',         label: 'RAM',              specsTable: 'ram_specs',         icon: '💾' },
-  { value: 'gpu',         label: 'Carte graphique',  specsTable: 'gpu_specs',         icon: '🎮' },
-  { value: 'storage',     label: 'Stockage',         specsTable: 'storage_specs',     icon: '💿' },
-  { value: 'psu',         label: 'Alimentation',     specsTable: 'psu_specs',         icon: '⚡' },
-  { value: 'pc_case',     label: 'Boîtier',          specsTable: 'pc_case_specs',     icon: '📦' },
-  { value: 'cpu_cooler',  label: 'Ventirad',         specsTable: 'cpu_cooler_specs',  icon: '❄️' },
+  { value: 'motherboard', label: 'Carte mère',      specsTable: 'motherboard_specs', icon: '🔌' },
+  { value: 'pc_case',     label: 'Boîtier',         specsTable: 'pc_case_specs',     icon: '📦' },
+  { value: 'ram',         label: 'RAM',             specsTable: 'ram_specs',         icon: '💾' },
+  { value: 'gpu',         label: 'Carte graphique', specsTable: 'gpu_specs',         icon: '🎮' },
+  { value: 'storage',     label: 'Stockage',        specsTable: 'storage_specs',     icon: '💿' },
+  { value: 'cpu_cooler',  label: 'Ventirad',        specsTable: 'cpu_cooler_specs',  icon: '❄️' },
+  { value: 'psu',         label: 'Alimentation',    specsTable: 'psu_specs',         icon: '⚡' },
 ]
 
 // Key specs displayed on product cards — aligned with actual DB column names

--- a/src/utils/__tests__/compatibility.integration.test.ts
+++ b/src/utils/__tests__/compatibility.integration.test.ts
@@ -46,20 +46,21 @@ beforeEach(() => {
 })
 
 describe('Configurator flow — chained compatibility filters', () => {
-  it('AM5 build: selects mobo → filters CPU and RAM with correct constraints', async () => {
+  it('AM5 build: selects CPU → mobo filtered by socket; once mobo picked → RAM by ram_type', async () => {
+    const cpu = prod({ socket: 'AM5', tdp: 105 })
     const mobo = prod({ socket: 'AM5', ram_type: 'DDR5', form_factor: 'ATX' })
 
     state.queue = [
-      { data: [{ product_id: 'cpu-1' }, { product_id: 'cpu-2' }], error: null },
+      { data: [{ product_id: 'mb-1' }, { product_id: 'mb-2' }], error: null },
       { data: [{ product_id: 'ram-1' }], error: null },
     ]
 
-    const cpuRes = await getCompatibleProductIds('cpu', { motherboard: mobo })
-    const ramRes = await getCompatibleProductIds('ram', { motherboard: mobo })
+    const moboRes = await getCompatibleProductIds('motherboard', { cpu })
+    const ramRes = await getCompatibleProductIds('ram', { cpu, motherboard: mobo })
 
-    expect(cpuRes.productIds).toEqual(['cpu-1', 'cpu-2'])
+    expect(moboRes.productIds).toEqual(['mb-1', 'mb-2'])
     expect(ramRes.productIds).toEqual(['ram-1'])
-    expect(state.callLog[0].table).toBe('cpu_specs')
+    expect(state.callLog[0].table).toBe('motherboard_specs')
     expect(state.callLog[0].ops).toContain('eq(socket=AM5)')
     expect(state.callLog[1].table).toBe('ram_specs')
     expect(state.callLog[1].ops).toContain('eq(ram_type=DDR5)')
@@ -90,22 +91,19 @@ describe('Configurator flow — chained compatibility filters', () => {
     expect(state.callLog[0].ops).toContainEqual('gte(wattage>=864)')
   })
 
-  it('ITX build: mobo filtered by both CPU socket AND case form factor', async () => {
-    const cpu = prod({ socket: 'AM5' })
-    const pcCase = prod({ supported_mobo_form_factors: ['Mini ITX'] })
+  it('ITX build: mobo (Mini ITX) selected → case filtered by form factor', async () => {
+    const mobo = prod({ form_factor: 'Mini ITX', ram_type: 'DDR5' })
 
     state.queue = [{
-      data: [
-        { product_id: 'mb-atx', form_factor: 'ATX' },
-        { product_id: 'mb-itx', form_factor: 'Mini ITX' },
-      ],
+      data: [{ product_id: 'case-itx' }],
       error: null,
     }]
 
-    const res = await getCompatibleProductIds('motherboard', { cpu, pc_case: pcCase })
+    const res = await getCompatibleProductIds('pc_case', { motherboard: mobo })
 
-    expect(res.productIds).toEqual(['mb-itx'])
-    expect(res.reason).toContain('Socket AM5')
+    expect(res.productIds).toEqual(['case-itx'])
+    expect(state.callLog[0].table).toBe('pc_case_specs')
+    expect(state.callLog[0].ops).toContainEqual('contains(supported_mobo_form_factors=["Mini ITX"])')
     expect(res.reason).toContain('Mini ITX')
   })
 

--- a/src/utils/__tests__/compatibility.test.ts
+++ b/src/utils/__tests__/compatibility.test.ts
@@ -3,13 +3,14 @@ import { getCompatibleProductIds } from '../compatibility'
 import type { Product } from '../../types'
 
 // Chainable mock that resolves with configurable data
-let mockResolvedData: { product_id: string; form_factor?: string }[] = []
+let mockResolvedData: { product_id: string; form_factor?: string; height_mm?: number; length_mm?: number }[] = []
 
 const mockBuilder = {
   select: vi.fn().mockReturnThis(),
   eq: vi.fn().mockReturnThis(),
   contains: vi.fn().mockReturnThis(),
   gte: vi.fn().mockReturnThis(),
+  or: vi.fn().mockReturnThis(),
   then(resolve: (v: { data: typeof mockResolvedData; error: null }) => void) {
     return Promise.resolve({ data: mockResolvedData, error: null }).then(resolve)
   },
@@ -47,27 +48,44 @@ beforeEach(() => {
 
 describe('getCompatibleProductIds', () => {
   describe('cpu', () => {
-    it('returns filtered:false when no motherboard selected', async () => {
+    it('is never filtered (cpu is first in selection order)', async () => {
       const result = await getCompatibleProductIds('cpu', {})
       expect(result.filtered).toBe(false)
     })
+  })
 
-    it('returns filtered:false when motherboard has no socket', async () => {
-      const result = await getCompatibleProductIds('cpu', {
-        motherboard: makeProduct({}),
-      })
+  describe('motherboard', () => {
+    it('returns filtered:false when no cpu selected', async () => {
+      const result = await getCompatibleProductIds('motherboard', {})
       expect(result.filtered).toBe(false)
     })
 
-    it('queries cpu_specs by socket and returns ids', async () => {
-      mockResolvedData = [{ product_id: 'cpu-1' }, { product_id: 'cpu-2' }]
-      const result = await getCompatibleProductIds('cpu', {
-        motherboard: makeProduct({ socket: 'AM4' }),
+    it('filters by cpu socket', async () => {
+      mockResolvedData = [{ product_id: 'mb-1' }]
+      const result = await getCompatibleProductIds('motherboard', {
+        cpu: makeProduct({ socket: 'AM5' }),
       })
       expect(result.filtered).toBe(true)
-      expect(result.productIds).toEqual(['cpu-1', 'cpu-2'])
-      expect(result.reason).toBe('Socket AM4')
-      expect(mockBuilder.eq).toHaveBeenCalledWith('socket', 'AM4')
+      expect(result.productIds).toEqual(['mb-1'])
+      expect(mockBuilder.eq).toHaveBeenCalledWith('socket', 'AM5')
+      expect(result.reason).toBe('Socket AM5')
+    })
+  })
+
+  describe('pc_case', () => {
+    it('returns filtered:false when no motherboard selected', async () => {
+      const result = await getCompatibleProductIds('pc_case', {})
+      expect(result.filtered).toBe(false)
+    })
+
+    it('queries pc_case_specs by form_factor containment', async () => {
+      mockResolvedData = [{ product_id: 'case-1' }]
+      const result = await getCompatibleProductIds('pc_case', {
+        motherboard: makeProduct({ form_factor: 'ATX' }),
+      })
+      expect(result.filtered).toBe(true)
+      expect(result.productIds).toEqual(['case-1'])
+      expect(mockBuilder.contains).toHaveBeenCalledWith('supported_mobo_form_factors', ['ATX'])
     })
   })
 
@@ -89,95 +107,21 @@ describe('getCompatibleProductIds', () => {
     })
   })
 
-  describe('cpu_cooler', () => {
-    it('returns filtered:false when no cpu selected', async () => {
-      const result = await getCompatibleProductIds('cpu_cooler', {})
+  describe('gpu', () => {
+    it('returns filtered:false when no pc_case selected', async () => {
+      const result = await getCompatibleProductIds('gpu', {})
       expect(result.filtered).toBe(false)
     })
 
-    it('queries cpu_cooler_specs by socket array containment', async () => {
-      mockResolvedData = [{ product_id: 'cooler-1' }]
-      const result = await getCompatibleProductIds('cpu_cooler', {
-        cpu: makeProduct({ socket: 'LGA1700' }),
+    it('filters by case max GPU length', async () => {
+      mockResolvedData = [{ product_id: 'gpu-1' }]
+      const result = await getCompatibleProductIds('gpu', {
+        pc_case: makeProduct({ max_gpu_length_mm: 320 }),
       })
       expect(result.filtered).toBe(true)
-      expect(result.productIds).toEqual(['cooler-1'])
-      expect(mockBuilder.contains).toHaveBeenCalledWith('cpu_sockets', ['LGA1700'])
-    })
-  })
-
-  describe('pc_case', () => {
-    it('returns filtered:false when no motherboard selected', async () => {
-      const result = await getCompatibleProductIds('pc_case', {})
-      expect(result.filtered).toBe(false)
-    })
-
-    it('queries pc_case_specs by form_factor containment', async () => {
-      mockResolvedData = [{ product_id: 'case-1' }]
-      const result = await getCompatibleProductIds('pc_case', {
-        motherboard: makeProduct({ form_factor: 'ATX' }),
-      })
-      expect(result.filtered).toBe(true)
-      expect(result.productIds).toEqual(['case-1'])
-      expect(mockBuilder.contains).toHaveBeenCalledWith('supported_mobo_form_factors', ['ATX'])
-    })
-  })
-
-  describe('motherboard', () => {
-    it('returns filtered:false when neither cpu nor pc_case selected', async () => {
-      const result = await getCompatibleProductIds('motherboard', {})
-      expect(result.filtered).toBe(false)
-    })
-
-    it('filters by cpu socket only', async () => {
-      mockResolvedData = [{ product_id: 'mb-1', form_factor: 'ATX' }]
-      const result = await getCompatibleProductIds('motherboard', {
-        cpu: makeProduct({ socket: 'AM5' }),
-      })
-      expect(result.filtered).toBe(true)
-      expect(result.productIds).toEqual(['mb-1'])
-      expect(mockBuilder.eq).toHaveBeenCalledWith('socket', 'AM5')
-    })
-
-    it('filters by both socket and case form factors', async () => {
-      mockResolvedData = [
-        { product_id: 'mb-1', form_factor: 'ATX' },
-        { product_id: 'mb-2', form_factor: 'mATX' },
-      ]
-      const result = await getCompatibleProductIds('motherboard', {
-        cpu: makeProduct({ socket: 'AM5' }),
-        pc_case: makeProduct({ supported_mobo_form_factors: ['ATX'] }),
-      })
-      expect(result.filtered).toBe(true)
-      expect(result.productIds).toEqual(['mb-1'])
-    })
-  })
-
-  describe('psu', () => {
-    it('returns filtered:false when no gpu or cpu tdp', async () => {
-      const result = await getCompatibleProductIds('psu', {})
-      expect(result.filtered).toBe(false)
-    })
-
-    it('calculates min wattage from gpu+cpu TDP with 20% headroom', async () => {
-      mockResolvedData = [{ product_id: 'psu-1' }]
-      // gpu: 300W, cpu: 65W → system = 300+65+100 = 465W → min = ceil(465*1.2) = 558W
-      const result = await getCompatibleProductIds('psu', {
-        gpu: makeProduct({ tdp: 300 }),
-        cpu: makeProduct({ tdp: 65 }),
-      })
-      expect(result.filtered).toBe(true)
-      expect(mockBuilder.gte).toHaveBeenCalledWith('wattage', 558)
-      expect(result.reason).toContain('558W')
-    })
-
-    it('works with gpu only (no cpu)', async () => {
-      mockResolvedData = []
-      // gpu: 200W → system = 200+0+100 = 300W → min = ceil(300*1.2) = 360W
-      await getCompatibleProductIds('psu', {
-        gpu: makeProduct({ tdp: 200 }),
-      })
-      expect(mockBuilder.gte).toHaveBeenCalledWith('wattage', 360)
+      expect(result.productIds).toEqual(['gpu-1'])
+      expect(mockBuilder.or).toHaveBeenCalledWith('length_mm.lte.320,length_mm.is.null')
+      expect(result.reason).toContain('320 mm')
     })
   })
 
@@ -215,10 +159,60 @@ describe('getCompatibleProductIds', () => {
     })
   })
 
-  describe('default / unhandled categories', () => {
-    it('returns filtered:false for gpu category', async () => {
-      const result = await getCompatibleProductIds('gpu', {})
+  describe('cpu_cooler', () => {
+    it('returns filtered:false when no cpu selected', async () => {
+      const result = await getCompatibleProductIds('cpu_cooler', {})
       expect(result.filtered).toBe(false)
+    })
+
+    it('filters by socket only when no case is selected', async () => {
+      mockResolvedData = [{ product_id: 'cooler-1' }]
+      const result = await getCompatibleProductIds('cpu_cooler', {
+        cpu: makeProduct({ socket: 'LGA1700' }),
+      })
+      expect(result.filtered).toBe(true)
+      expect(mockBuilder.contains).toHaveBeenCalledWith('cpu_sockets', ['LGA1700'])
+      expect(mockBuilder.or).not.toHaveBeenCalled()
+      expect(result.reason).toBe('Socket LGA1700')
+    })
+
+    it('filters by socket and case max cooler height', async () => {
+      mockResolvedData = [{ product_id: 'cooler-2' }]
+      const result = await getCompatibleProductIds('cpu_cooler', {
+        cpu: makeProduct({ socket: 'AM5' }),
+        pc_case: makeProduct({ max_cpu_cooler_height_mm: 165 }),
+      })
+      expect(result.filtered).toBe(true)
+      expect(mockBuilder.contains).toHaveBeenCalledWith('cpu_sockets', ['AM5'])
+      expect(mockBuilder.or).toHaveBeenCalledWith('height_mm.lte.165,height_mm.is.null')
+      expect(result.reason).toContain('165 mm')
+    })
+  })
+
+  describe('psu', () => {
+    it('returns filtered:false when no gpu or cpu tdp', async () => {
+      const result = await getCompatibleProductIds('psu', {})
+      expect(result.filtered).toBe(false)
+    })
+
+    it('calculates min wattage from gpu+cpu TDP with 20% headroom', async () => {
+      mockResolvedData = [{ product_id: 'psu-1' }]
+      const result = await getCompatibleProductIds('psu', {
+        gpu: makeProduct({ tdp: 300 }),
+        cpu: makeProduct({ tdp: 65 }),
+      })
+      expect(result.filtered).toBe(true)
+      expect(mockBuilder.gte).toHaveBeenCalledWith('wattage', 558)
+      expect(result.reason).toContain('558W')
+    })
+
+    it('works with cpu only (no gpu)', async () => {
+      mockResolvedData = []
+      // cpu: 65W → system = 65+0+100 = 165W → min = ceil(165*1.2) = 198W
+      await getCompatibleProductIds('psu', {
+        cpu: makeProduct({ tdp: 65 }),
+      })
+      expect(mockBuilder.gte).toHaveBeenCalledWith('wattage', 198)
     })
   })
 })

--- a/src/utils/__tests__/selection-order.test.ts
+++ b/src/utils/__tests__/selection-order.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PREREQS,
+  SELECTION_ORDER,
+  cascadeInvalidations,
+  missingPrereqs,
+  nextPendingCategory,
+  prereqsMet,
+} from '../selection-order'
+import type { CategoryKey, Product } from '../../types'
+
+function makeProduct(specs: Record<string, unknown>, id = 'p1'): Product {
+  return {
+    id,
+    name: 'Test',
+    manufacturer: 'Test',
+    series: null,
+    variant: null,
+    release_year: null,
+    category: 'cpu',
+    image_url: null,
+    description: null,
+    price_min_eur: null,
+    price_max_eur: null,
+    price_avg_eur: null,
+    price_updated_at: null,
+    retailer_url: null,
+    benchmark_score: null,
+    specs,
+  }
+}
+
+describe('SELECTION_ORDER', () => {
+  it('contains all 8 categories exactly once', () => {
+    expect(SELECTION_ORDER).toHaveLength(8)
+    expect(new Set(SELECTION_ORDER).size).toBe(8)
+  })
+
+  it('starts with cpu', () => {
+    expect(SELECTION_ORDER[0]).toBe('cpu')
+  })
+
+  it('places motherboard right after cpu', () => {
+    expect(SELECTION_ORDER[1]).toBe('motherboard')
+  })
+
+  it('places pc_case before gpu (gpu needs case length)', () => {
+    expect(SELECTION_ORDER.indexOf('pc_case')).toBeLessThan(SELECTION_ORDER.indexOf('gpu'))
+  })
+
+  it('places pc_case before cpu_cooler (cooler needs case height)', () => {
+    expect(SELECTION_ORDER.indexOf('pc_case')).toBeLessThan(SELECTION_ORDER.indexOf('cpu_cooler'))
+  })
+
+  it('places psu after gpu (psu needs gpu TDP)', () => {
+    expect(SELECTION_ORDER.indexOf('gpu')).toBeLessThan(SELECTION_ORDER.indexOf('psu'))
+  })
+})
+
+describe('PREREQS', () => {
+  it('cpu has no prereqs', () => {
+    expect(PREREQS.cpu).toEqual([])
+  })
+
+  it('motherboard requires cpu', () => {
+    expect(PREREQS.motherboard).toEqual(['cpu'])
+  })
+
+  it('pc_case, ram, storage require motherboard', () => {
+    expect(PREREQS.pc_case).toContain('motherboard')
+    expect(PREREQS.ram).toContain('motherboard')
+    expect(PREREQS.storage).toContain('motherboard')
+  })
+})
+
+describe('missingPrereqs / prereqsMet', () => {
+  it('returns empty when all prereqs are satisfied', () => {
+    const config = { cpu: makeProduct({ socket: 'AM5' }) }
+    expect(missingPrereqs('motherboard', config)).toEqual([])
+    expect(prereqsMet('motherboard', config)).toBe(true)
+  })
+
+  it('returns missing prereqs', () => {
+    expect(missingPrereqs('ram', {})).toEqual(['motherboard'])
+    expect(prereqsMet('ram', {})).toBe(false)
+  })
+})
+
+describe('cascadeInvalidations', () => {
+  it('removes incompatible motherboard when cpu changes socket', () => {
+    const config = {
+      cpu: makeProduct({ socket: 'LGA1700' }, 'cpu1'),
+      motherboard: makeProduct({ socket: 'AM5', form_factor: 'ATX', ram_type: 'DDR5' }, 'mb1'),
+    }
+    expect(cascadeInvalidations('cpu', config)).toEqual(['motherboard'])
+  })
+
+  it('removes ram and pc_case downstream when motherboard would invalidate them', () => {
+    const config = {
+      cpu: makeProduct({ socket: 'AM5' }, 'cpu1'),
+      motherboard: makeProduct({ form_factor: 'ITX', ram_type: 'DDR5' }, 'mb1'),
+      pc_case: makeProduct({ supported_mobo_form_factors: ['ATX'] }, 'case1'),
+      ram: makeProduct({ ram_type: 'DDR4' }, 'ram1'),
+    }
+    const invalidated = cascadeInvalidations('motherboard', config)
+    expect(invalidated).toContain('pc_case')
+    expect(invalidated).toContain('ram')
+  })
+
+  it('removes cooler when case max height is exceeded', () => {
+    const config = {
+      cpu: makeProduct({ socket: 'AM5' }, 'cpu1'),
+      pc_case: makeProduct({ max_cpu_cooler_height_mm: 80 }, 'case1'),
+      cpu_cooler: makeProduct({ cpu_sockets: ['AM5'], height_mm: 160 }, 'cooler1'),
+    }
+    expect(cascadeInvalidations('pc_case', config)).toEqual(['cpu_cooler'])
+  })
+
+  it('removes gpu when case max length is exceeded', () => {
+    const config = {
+      pc_case: makeProduct({ max_gpu_length_mm: 250 }, 'case1'),
+      gpu: makeProduct({ length_mm: 320 }, 'gpu1'),
+    }
+    expect(cascadeInvalidations('pc_case', config)).toContain('gpu')
+  })
+
+  it('does nothing when changes remain compatible', () => {
+    const config = {
+      cpu: makeProduct({ socket: 'AM5' }, 'cpu1'),
+      motherboard: makeProduct({ socket: 'AM5', ram_type: 'DDR5' }, 'mb1'),
+      ram: makeProduct({ ram_type: 'DDR5' }, 'ram1'),
+    }
+    expect(cascadeInvalidations('cpu', config)).toEqual([])
+  })
+})
+
+describe('nextPendingCategory', () => {
+  it('returns cpu when config is empty', () => {
+    expect(nextPendingCategory({})).toBe('cpu')
+  })
+
+  it('returns the next missing category in order', () => {
+    const config: Partial<Record<CategoryKey, Product>> = {
+      cpu: makeProduct({}),
+      motherboard: makeProduct({}),
+    }
+    expect(nextPendingCategory(config)).toBe('pc_case')
+  })
+
+  it('returns null when all categories are filled', () => {
+    const config: Partial<Record<CategoryKey, Product>> = {}
+    for (const cat of SELECTION_ORDER) {
+      config[cat] = makeProduct({})
+    }
+    expect(nextPendingCategory(config)).toBeNull()
+  })
+})

--- a/src/utils/compatibility.ts
+++ b/src/utils/compatibility.ts
@@ -10,6 +10,10 @@ export interface CompatibilityResult {
 /**
  * Returns compatible product IDs for a target category based on already selected components.
  * Returns { filtered: false } if no relevant component is selected yet.
+ *
+ * L'ordre logique de sélection (cf. utils/selection-order.ts) garantit qu'au moment où on
+ * filtre une catégorie, ses pré-requis sont déjà sélectionnés. La fonction reste défensive
+ * (filtered:false si un pré-requis manque) pour rester utilisable en standalone.
  */
 export async function getCompatibleProductIds(
   targetCategory: CategoryKey,
@@ -17,48 +21,21 @@ export async function getCompatibleProductIds(
 ): Promise<CompatibilityResult> {
   const cpu = config['cpu']
   const motherboard = config['motherboard']
+  const pcCase = config['pc_case']
 
   switch (targetCategory) {
-    case 'cpu': {
-      const socket = motherboard?.specs?.['socket'] as string | undefined
-      if (!socket) return { filtered: false, productIds: [] }
+    // CPU est le point de départ : aucun filtre n'est appliqué (ordre verrouillé en amont).
+    case 'cpu':
+      return { filtered: false, productIds: [] }
 
-      const { data } = await supabase
-        .from('cpu_specs')
-        .select('product_id')
-        .eq('socket', socket)
-
-      return {
-        filtered: true,
-        productIds: data?.map((r) => r.product_id) ?? [],
-        reason: `Socket ${socket}`,
-      }
-    }
-
-    case 'ram': {
-      const ramType = motherboard?.specs?.['ram_type'] as string | undefined
-      if (!ramType) return { filtered: false, productIds: [] }
-
-      const { data } = await supabase
-        .from('ram_specs')
-        .select('product_id')
-        .eq('ram_type', ramType)
-
-      return {
-        filtered: true,
-        productIds: data?.map((r) => r.product_id) ?? [],
-        reason: ramType,
-      }
-    }
-
-    case 'cpu_cooler': {
+    case 'motherboard': {
       const socket = cpu?.specs?.['socket'] as string | undefined
       if (!socket) return { filtered: false, productIds: [] }
 
       const { data } = await supabase
-        .from('cpu_cooler_specs')
+        .from('motherboard_specs')
         .select('product_id')
-        .contains('cpu_sockets', [socket])
+        .eq('socket', socket)
 
       return {
         filtered: true,
@@ -79,67 +56,48 @@ export async function getCompatibleProductIds(
       return {
         filtered: true,
         productIds: data?.map((r) => r.product_id) ?? [],
-        reason: formFactor,
+        reason: `Format ${formFactor}`,
       }
     }
 
-    // US-034 — Compatibilité Boîtier → Carte mère (format ATX/mATX/ITX)
-    case 'motherboard': {
-      const pcCase = config['pc_case']
-      const socket = cpu?.specs?.['socket'] as string | undefined
-      const caseFormFactors = pcCase?.specs?.['supported_mobo_form_factors'] as string[] | undefined
-
-      if (!socket && !caseFormFactors?.length) return { filtered: false, productIds: [] }
-
-      let query = supabase.from('motherboard_specs').select('product_id, form_factor')
-      if (socket) query = query.eq('socket', socket)
-
-      const { data } = await query
-
-      if (!data?.length) return { filtered: true, productIds: [], reason: socket ? `Socket ${socket}` : undefined }
-
-      // Filtre supplémentaire par format de boîtier si boîtier sélectionné
-      if (caseFormFactors?.length) {
-        const filtered = data.filter((r) => {
-          const mf = (r as Record<string, unknown>)['form_factor'] as string | undefined
-          return mf ? caseFormFactors.includes(mf) : true
-        })
-        const reason = [socket && `Socket ${socket}`, pcCase && `Format ${caseFormFactors.join('/')}`]
-          .filter(Boolean).join(' · ')
-        return { filtered: true, productIds: filtered.map((r) => r.product_id), reason }
-      }
-
-      return { filtered: true, productIds: data.map((r) => r.product_id), reason: socket ? `Socket ${socket}` : undefined }
-    }
-
-    // US-033 — Compatibilité GPU / Alimentation (calcul TDP)
-    case 'psu': {
-      const gpu = config['gpu']
-      const gpuTdp = gpu?.specs?.['tdp'] as number | undefined
-      const cpuTdp = cpu?.specs?.['tdp'] as number | undefined
-
-      if (!gpuTdp && !cpuTdp) return { filtered: false, productIds: [] }
-
-      const systemTdp = (gpuTdp ?? 0) + (cpuTdp ?? 0) + 100 // +100W buffer système
-      const minWattage = Math.ceil(systemTdp * 1.2) // 20% headroom recommandé
+    case 'ram': {
+      const ramType = motherboard?.specs?.['ram_type'] as string | undefined
+      if (!ramType) return { filtered: false, productIds: [] }
 
       const { data } = await supabase
-        .from('psu_specs')
+        .from('ram_specs')
         .select('product_id')
-        .gte('wattage', minWattage)
+        .eq('ram_type', ramType)
 
       return {
         filtered: true,
         productIds: data?.map((r) => r.product_id) ?? [],
-        reason: `≥ ${minWattage}W (TDP système ~${systemTdp}W)`,
+        reason: ramType,
       }
     }
 
-    // US-035 — Compatibilité Stockage / Connectique carte mère (M.2/SATA)
+    // GPU : aucun filtre tant que le boîtier n'est pas sélectionné. Sinon, on filtre
+    // par longueur max GPU supportée.
+    case 'gpu': {
+      const maxLen = pcCase?.specs?.['max_gpu_length_mm'] as number | undefined
+      if (!maxLen) return { filtered: false, productIds: [] }
+
+      const { data } = await supabase
+        .from('gpu_specs')
+        .select('product_id, length_mm')
+        .or(`length_mm.lte.${maxLen},length_mm.is.null`)
+
+      return {
+        filtered: true,
+        productIds: data?.map((r) => r.product_id) ?? [],
+        reason: `Longueur ≤ ${maxLen} mm`,
+      }
+    }
+
     case 'storage': {
       if (!motherboard) return { filtered: false, productIds: [] }
 
-      const m2Slots  = motherboard.specs?.['m2_slots']  as number | undefined
+      const m2Slots   = motherboard.specs?.['m2_slots']  as number | undefined
       const sataPorts = motherboard.specs?.['sata_6gbs'] as number | undefined
 
       const hasM2   = (m2Slots ?? 0) > 0
@@ -148,7 +106,6 @@ export async function getCompatibleProductIds(
       if (!hasM2 && !hasSata) return { filtered: false, productIds: [] }
       if (hasM2 && hasSata)   return { filtered: false, productIds: [] } // tout compatible
 
-      // Pas de M.2 → exclure NVMe
       if (!hasM2 && hasSata) {
         const { data } = await supabase
           .from('storage_specs')
@@ -162,7 +119,6 @@ export async function getCompatibleProductIds(
         }
       }
 
-      // Pas de SATA → exclure les disques SATA non-NVMe
       const { data } = await supabase
         .from('storage_specs')
         .select('product_id')
@@ -172,6 +128,54 @@ export async function getCompatibleProductIds(
         filtered: true,
         productIds: data?.map((r) => r.product_id) ?? [],
         reason: 'Pas de port SATA — M.2 NVMe uniquement',
+      }
+    }
+
+    // Ventirad : socket CPU + hauteur max boîtier (si boîtier sélectionné).
+    case 'cpu_cooler': {
+      const socket = cpu?.specs?.['socket'] as string | undefined
+      if (!socket) return { filtered: false, productIds: [] }
+
+      const maxH = pcCase?.specs?.['max_cpu_cooler_height_mm'] as number | undefined
+
+      let query = supabase
+        .from('cpu_cooler_specs')
+        .select('product_id, height_mm')
+        .contains('cpu_sockets', [socket])
+
+      if (maxH) {
+        query = query.or(`height_mm.lte.${maxH},height_mm.is.null`)
+      }
+
+      const { data } = await query
+      const reason = maxH ? `Socket ${socket} · hauteur ≤ ${maxH} mm` : `Socket ${socket}`
+
+      return {
+        filtered: true,
+        productIds: data?.map((r) => r.product_id) ?? [],
+        reason,
+      }
+    }
+
+    case 'psu': {
+      const gpu = config['gpu']
+      const gpuTdp = gpu?.specs?.['tdp'] as number | undefined
+      const cpuTdp = cpu?.specs?.['tdp'] as number | undefined
+
+      if (!gpuTdp && !cpuTdp) return { filtered: false, productIds: [] }
+
+      const systemTdp = (gpuTdp ?? 0) + (cpuTdp ?? 0) + 100
+      const minWattage = Math.ceil(systemTdp * 1.2)
+
+      const { data } = await supabase
+        .from('psu_specs')
+        .select('product_id')
+        .gte('wattage', minWattage)
+
+      return {
+        filtered: true,
+        productIds: data?.map((r) => r.product_id) ?? [],
+        reason: `≥ ${minWattage}W (TDP système ~${systemTdp}W)`,
       }
     }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './compatibility'
+export * from './selection-order'

--- a/src/utils/selection-order.ts
+++ b/src/utils/selection-order.ts
@@ -1,0 +1,165 @@
+import type { CategoryKey, Product } from '../types'
+
+/**
+ * Ordre recommandé de sélection des composants.
+ * Suit la logique d'un montage PC : on part du CPU (qui définit le socket),
+ * puis la carte mère, puis on choisit le boîtier (qui contraint GPU/ventirad),
+ * puis les composants secondaires.
+ */
+export const SELECTION_ORDER: CategoryKey[] = [
+  'cpu',
+  'motherboard',
+  'pc_case',
+  'ram',
+  'gpu',
+  'storage',
+  'cpu_cooler',
+  'psu',
+]
+
+/**
+ * Pré-requis stricts : pour pouvoir sélectionner X, ces catégories doivent
+ * déjà être renseignées (faute de quoi les règles de compatibilité ne peuvent
+ * pas s'appliquer correctement).
+ */
+export const PREREQS: Record<CategoryKey, CategoryKey[]> = {
+  cpu: [],
+  motherboard: ['cpu'],
+  pc_case: ['motherboard'],
+  ram: ['motherboard'],
+  storage: ['motherboard'],
+  gpu: [],
+  cpu_cooler: ['cpu'],
+  psu: ['cpu'],
+}
+
+/** Pré-requis manquants pour une catégorie donnée. */
+export function missingPrereqs(
+  category: CategoryKey,
+  config: Partial<Record<CategoryKey, Product>>,
+): CategoryKey[] {
+  return PREREQS[category].filter((p) => !config[p])
+}
+
+/** Toutes les pré-conditions sont-elles satisfaites ? */
+export function prereqsMet(
+  category: CategoryKey,
+  config: Partial<Record<CategoryKey, Product>>,
+): boolean {
+  return missingPrereqs(category, config).length === 0
+}
+
+/**
+ * Vérifie de manière synchrone (sans DB, uniquement sur les specs en mémoire)
+ * qu'un produit déjà sélectionné reste compatible avec la nouvelle config.
+ * Sert au cascade invalidation : on évite les allers-retours réseau.
+ */
+function specIsCompatible(
+  category: CategoryKey,
+  product: Product,
+  config: Partial<Record<CategoryKey, Product>>,
+): boolean {
+  const specs = product.specs ?? {}
+  const cpu = config['cpu']
+  const motherboard = config['motherboard']
+  const pcCase = config['pc_case']
+  const gpu = config['gpu']
+
+  switch (category) {
+    case 'motherboard': {
+      const cpuSocket = cpu?.specs?.['socket'] as string | undefined
+      if (cpuSocket && specs['socket'] !== cpuSocket) return false
+      return true
+    }
+    case 'ram': {
+      const ramType = motherboard?.specs?.['ram_type'] as string | undefined
+      if (ramType && specs['ram_type'] !== ramType) return false
+      return true
+    }
+    case 'pc_case': {
+      const mobof = motherboard?.specs?.['form_factor'] as string | undefined
+      const supported = specs['supported_mobo_form_factors'] as string[] | undefined
+      if (mobof && supported && !supported.includes(mobof)) return false
+      return true
+    }
+    case 'storage': {
+      const m2Slots = motherboard?.specs?.['m2_slots'] as number | undefined
+      const sataPorts = motherboard?.specs?.['sata_6gbs'] as number | undefined
+      const isNvme = specs['nvme'] as boolean | undefined
+      if (m2Slots !== undefined && sataPorts !== undefined && isNvme !== undefined) {
+        if (isNvme && m2Slots === 0) return false
+        if (!isNvme && sataPorts === 0) return false
+      }
+      return true
+    }
+    case 'cpu_cooler': {
+      const cpuSocket = cpu?.specs?.['socket'] as string | undefined
+      const supported = specs['cpu_sockets'] as string[] | undefined
+      if (cpuSocket && supported && !supported.includes(cpuSocket)) return false
+      const maxH = pcCase?.specs?.['max_cpu_cooler_height_mm'] as number | undefined
+      const coolerH = specs['height_mm'] as number | undefined
+      if (maxH && coolerH && coolerH > maxH) return false
+      return true
+    }
+    case 'gpu': {
+      const maxL = pcCase?.specs?.['max_gpu_length_mm'] as number | undefined
+      const gpuL = specs['length_mm'] as number | undefined
+      if (maxL && gpuL && gpuL > maxL) return false
+      return true
+    }
+    case 'psu': {
+      const gpuTdp = (gpu?.specs?.['tdp'] as number | undefined) ?? 0
+      const cpuTdp = (cpu?.specs?.['tdp'] as number | undefined) ?? 0
+      const wattage = specs['wattage'] as number | undefined
+      if (wattage !== undefined && (gpuTdp || cpuTdp)) {
+        const minWattage = Math.ceil((gpuTdp + cpuTdp + 100) * 1.2)
+        if (wattage < minWattage) return false
+      }
+      return true
+    }
+    case 'cpu':
+      return true
+  }
+}
+
+/**
+ * Renvoie la liste des catégories à invalider en cascade quand `changed`
+ * vient de changer (sélection ou suppression). On parcourt l'ordre de
+ * sélection en aval et on retire toute sélection qui n'est plus compatible.
+ */
+export function cascadeInvalidations(
+  changed: CategoryKey,
+  config: Partial<Record<CategoryKey, Product>>,
+): CategoryKey[] {
+  const order = SELECTION_ORDER
+  const startIdx = order.indexOf(changed)
+  if (startIdx < 0) return []
+
+  const toRemove: CategoryKey[] = []
+  const working: Partial<Record<CategoryKey, Product>> = { ...config }
+
+  for (let i = startIdx + 1; i < order.length; i++) {
+    const cat = order[i]
+    const product = working[cat]
+    if (!product) continue
+    if (!specIsCompatible(cat, product, working)) {
+      toRemove.push(cat)
+      delete working[cat]
+    }
+  }
+
+  return toRemove
+}
+
+/**
+ * Renvoie la prochaine catégorie à compléter dans l'ordre de sélection,
+ * ou null si tout est sélectionné.
+ */
+export function nextPendingCategory(
+  config: Partial<Record<CategoryKey, Product>>,
+): CategoryKey | null {
+  for (const cat of SELECTION_ORDER) {
+    if (!config[cat]) return cat
+  }
+  return null
+}


### PR DESCRIPTION
…asses de compatibilité

- Nouvel ordre logique de montage : CPU → MOBO → Boîtier → RAM → GPU → Stockage → Ventirad → PSU
- Pré-requis stricts par catégorie (utils/selection-order.ts) avec onglets verrouillés tant que les composants amont ne sont pas choisis
- Cascade automatique : changer un composant amont retire les composants aval devenus incompatibles (toast d'alerte via le store zustand)
- Auto-advance vers la prochaine catégorie pending après chaque sélection
- Nouveaux filtres : GPU ↔ longueur max boîtier, Ventirad ↔ hauteur max boîtier
- Filtre carte mère simplifié : uniquement par socket CPU (suppression du bidirectionnel cassant)
- 18 nouveaux tests (selection-order + cpu_cooler/case), 60 tests verts