### PR TITLE
feat(sprint-5): sauvegarde et chargement des configurations (US-040 à US-044)

### DIFF
--- a/src/pages/Configurator/Configurator.scss
+++ b/src/pages/Configurator/Configurator.scss
@@ -86,6 +86,62 @@
       background: rgba(239, 68, 68, 0.05);
     }
   }
+
+  &__cta {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 8px;
+  }
+
+  &__save,
+  &__load {
+    flex: 1;
+    padding: 9px 8px;
+    border-radius: 7px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-2);
+    font-family: var(--fm);
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.13s;
+    letter-spacing: 0.04em;
+
+    &:hover:not(:disabled) {
+      border-color: var(--ind);
+      color: var(--text);
+      background: rgba(99, 102, 241, 0.05);
+    }
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+  }
+
+  &__save {
+    background: var(--ind);
+    border-color: var(--ind);
+    color: #fff;
+
+    &:hover:not(:disabled) {
+      background: rgba(99, 102, 241, 0.9);
+      color: #fff;
+    }
+  }
+
+  &__login-hint {
+    font-family: var(--fb);
+    font-size: 11px;
+    color: var(--text-3);
+    margin-bottom: 8px;
+    line-height: 1.4;
+
+    a {
+      color: var(--ind);
+      text-decoration: underline;
+    }
+  }
 }
 
 .config-prog {
@@ -112,6 +168,15 @@
     font-family: var(--fm);
     font-size: 10px;
     color: var(--text-3);
+  }
+
+  &__complete {
+    margin-top: 10px;
+    font-family: var(--fm);
+    font-size: 10px;
+    color: var(--ok);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
   }
 }
 

--- a/src/pages/Configurator/Configurator.tsx
+++ b/src/pages/Configurator/Configurator.tsx
@@ -2,10 +2,13 @@ import { useState, useEffect, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { supabase } from '../../config'
 import { useConfigStore, useToast } from '../../store'
+import { useAuth } from '../../context/useAuth'
 import { CATEGORIES } from '../../types'
 import { KEY_SPECS, SPEC_LABELS, SPEC_UNITS } from '../../constants'
 import type { Product, CategoryKey } from '../../types'
 import { getCompatibleProductIds, missingPrereqs, nextPendingCategory, SELECTION_ORDER } from '../../utils'
+import { savedConfigsService } from '../../services'
+import SavedConfigsModal from './components/SavedConfigsModal'
 import './Configurator.scss'
 
 const PAGE_SIZE = 24
@@ -24,8 +27,21 @@ function categoryLabel(cat: CategoryKey): string {
 }
 
 function Configurator() {
-  const { config, lastInvalidated, selectComponent, removeComponent, clearInvalidated, clearConfig } = useConfigStore()
+  const {
+    config,
+    lastInvalidated,
+    loadedConfigName,
+    selectComponent,
+    removeComponent,
+    setLoadedConfigName,
+    clearInvalidated,
+    clearConfig,
+  } = useConfigStore()
   const toast = useToast()
+  const { isAuthenticated } = useAuth()
+
+  const [savedModalOpen, setSavedModalOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
 
   const [activeCategory, setActiveCategory] = useState<CategoryKey>('cpu')
   const [products, setProducts] = useState<Product[]>([])
@@ -162,8 +178,34 @@ function Configurator() {
   const selectedCount = Object.keys(config).length
   const totalPages = Math.ceil(totalCount / PAGE_SIZE)
   const progressPct = Math.round((selectedCount / CATEGORIES.length) * 100)
+  const isComplete = selectedCount === CATEGORIES.length
 
   const totalAvg = Object.values(config).reduce((acc, p) => acc + (p?.price_avg_eur ?? 0), 0)
+
+  const handleSave = async () => {
+    if (saving) return
+    const defaultName = loadedConfigName ?? `Config du ${new Date().toLocaleDateString('fr-FR')}`
+    const name = window.prompt('Nom de la configuration :', defaultName)
+    if (!name) return
+    const trimmed = name.trim()
+    if (!trimmed) {
+      toast.error('Le nom ne peut pas être vide')
+      return
+    }
+    setSaving(true)
+    const components: Partial<Record<CategoryKey, string>> = {}
+    for (const [cat, prod] of Object.entries(config) as [CategoryKey, Product][]) {
+      components[cat] = prod.id
+    }
+    const { data, error } = await savedConfigsService.create(trimmed, components)
+    setSaving(false)
+    if (error || !data) {
+      toast.error(error ?? 'Erreur de sauvegarde')
+      return
+    }
+    setLoadedConfigName(trimmed)
+    toast.success(`"${trimmed}" sauvegardée`)
+  }
 
   const activeCatDef = CATEGORIES.find((c) => c.value === activeCategory)!
 
@@ -173,13 +215,18 @@ function Configurator() {
     <div className="config-wrap">
       <aside className="config-side">
         <div className="config-side__hd">
-          <div className="config-side__title">Ma configuration</div>
+          <div className="config-side__title">
+            {loadedConfigName ?? 'Ma configuration'}
+          </div>
           <div className="config-prog">
             <div className="config-prog__bar">
               <div className="config-prog__fill" style={{ width: `${progressPct}%` }} />
             </div>
             <span className="config-prog__label">{selectedCount}/{CATEGORIES.length}</span>
           </div>
+          {isComplete && (
+            <div className="config-prog__complete">✓ Configuration complète</div>
+          )}
         </div>
 
         <div className="config-items">
@@ -238,6 +285,30 @@ function Configurator() {
           <div className="config-side__total-v">
             {totalAvg > 0 ? `${Math.round(totalAvg).toLocaleString('fr-FR')} €` : '—'}
           </div>
+          {isAuthenticated && (
+            <div className="config-side__cta">
+              <button
+                type="button"
+                className="config-side__save"
+                onClick={() => void handleSave()}
+                disabled={saving || selectedCount === 0}
+              >
+                {saving ? 'Sauvegarde…' : '💾 Sauvegarder'}
+              </button>
+              <button
+                type="button"
+                className="config-side__load"
+                onClick={() => setSavedModalOpen(true)}
+              >
+                Mes configs
+              </button>
+            </div>
+          )}
+          {!isAuthenticated && selectedCount > 0 && (
+            <div className="config-side__login-hint">
+              <Link to="/connexion">Connecte-toi</Link> pour sauvegarder ta configuration.
+            </div>
+          )}
           {selectedCount > 0 && (
             <button type="button" className="config-side__reset" onClick={clearConfig}>
               Réinitialiser
@@ -245,6 +316,8 @@ function Configurator() {
           )}
         </div>
       </aside>
+
+      <SavedConfigsModal isOpen={savedModalOpen} onClose={() => setSavedModalOpen(false)} />
 
       <main className="config-main">
         <div className="config-main__hd">

--- a/src/pages/Configurator/components/SavedConfigsModal.scss
+++ b/src/pages/Configurator/components/SavedConfigsModal.scss
@@ -1,0 +1,109 @@
+@use "../../../styles/variables" as *;
+
+.saved-configs {
+  &__state {
+    padding: 32px;
+    text-align: center;
+    color: var(--text-3);
+    font-family: var(--fb);
+    font-size: 13px;
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 14px 16px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    transition: border-color 0.15s;
+
+    &:hover {
+      border-color: var(--border-s);
+    }
+  }
+
+  &__main {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__name {
+    background: transparent;
+    border: none;
+    padding: 0;
+    color: var(--text);
+    font-family: var(--fh);
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    text-align: left;
+    text-decoration: none;
+
+    &:hover {
+      color: var(--ind);
+    }
+  }
+
+  &__rename {
+    background: var(--surface);
+    border: 1px solid var(--ind);
+    color: var(--text);
+    padding: 4px 8px;
+    border-radius: var(--rs);
+    font-family: var(--fh);
+    font-size: 15px;
+    font-weight: 600;
+    outline: none;
+    width: 100%;
+    max-width: 360px;
+  }
+
+  &__meta {
+    font-family: var(--fm);
+    font-size: 10px;
+    color: var(--text-3);
+    margin-top: 4px;
+    letter-spacing: 0.04em;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  &__btn {
+    background: transparent;
+    color: var(--text-2);
+    border: 1px solid var(--border);
+    padding: 6px 10px;
+    border-radius: var(--rs);
+    font-family: var(--fm);
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.13s;
+    letter-spacing: 0.04em;
+
+    &:hover {
+      border-color: var(--border-s);
+      color: var(--text);
+    }
+
+    &--danger:hover {
+      border-color: rgba(239, 68, 68, 0.3);
+      color: var(--err);
+      background: rgba(239, 68, 68, 0.05);
+    }
+  }
+}

--- a/src/pages/Configurator/components/SavedConfigsModal.tsx
+++ b/src/pages/Configurator/components/SavedConfigsModal.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react'
+import Modal from '../../../components/common/Modal/Modal'
+import { savedConfigsService, type SavedConfig } from '../../../services'
+import { CATEGORIES } from '../../../types'
+import { useConfigStore, useToast } from '../../../store'
+import './SavedConfigsModal.scss'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+
+function SavedConfigsModal({ isOpen, onClose }: Props) {
+  const toast = useToast()
+  const loadConfig = useConfigStore((s) => s.loadConfig)
+
+  const [configs, setConfigs] = useState<SavedConfig[] | null>(null)
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+
+  useEffect(() => {
+    if (!isOpen) return
+    let cancelled = false
+    async function load() {
+      const { data, error } = await savedConfigsService.list()
+      if (cancelled) return
+      if (error) toast.error(error)
+      else setConfigs(data)
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [isOpen, toast])
+
+  const loading = configs === null
+
+  const handleLoad = async (cfg: SavedConfig) => {
+    const hydrated = await savedConfigsService.hydrate(cfg)
+    loadConfig(hydrated.id, hydrated.name, hydrated.products)
+    if (hydrated.missing.length > 0) {
+      toast.warning(
+        `Config chargée — composants indisponibles : ${hydrated.missing
+          .map((c) => CATEGORIES.find((cat) => cat.value === c)?.label ?? c)
+          .join(', ')}`,
+      )
+    } else {
+      toast.success(`"${hydrated.name}" chargée`)
+    }
+    onClose()
+  }
+
+  const handleDelete = async (cfg: SavedConfig) => {
+    if (!window.confirm(`Supprimer la configuration "${cfg.name}" ?`)) return
+    const { error } = await savedConfigsService.delete(cfg.id)
+    if (error) toast.error(error)
+    else {
+      toast.success('Configuration supprimée')
+      setConfigs((prev) => (prev ?? []).filter((c) => c.id !== cfg.id))
+    }
+  }
+
+  const startRename = (cfg: SavedConfig) => {
+    setRenamingId(cfg.id)
+    setRenameValue(cfg.name)
+  }
+
+  const submitRename = async (cfg: SavedConfig) => {
+    const name = renameValue.trim()
+    if (!name || name === cfg.name) {
+      setRenamingId(null)
+      return
+    }
+    const { error } = await savedConfigsService.rename(cfg.id, name)
+    if (error) toast.error(error)
+    else {
+      toast.success('Nom mis à jour')
+      setConfigs((prev) => (prev ?? []).map((c) => (c.id === cfg.id ? { ...c, name } : c)))
+    }
+    setRenamingId(null)
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Mes configurations" size="lg">
+      {loading ? (
+        <div className="saved-configs__state">Chargement…</div>
+      ) : (configs ?? []).length === 0 ? (
+        <div className="saved-configs__state">Aucune configuration sauvegardée.</div>
+      ) : (
+        <ul className="saved-configs__list">
+          {(configs ?? []).map((cfg) => {
+            const componentCount = Object.values(cfg.components).filter(Boolean).length
+            const isRenaming = renamingId === cfg.id
+            return (
+              <li key={cfg.id} className="saved-configs__item">
+                <div className="saved-configs__main">
+                  {isRenaming ? (
+                    <input
+                      className="saved-configs__rename"
+                      autoFocus
+                      value={renameValue}
+                      maxLength={80}
+                      onChange={(e) => setRenameValue(e.target.value)}
+                      onBlur={() => void submitRename(cfg)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') void submitRename(cfg)
+                        if (e.key === 'Escape') setRenamingId(null)
+                      }}
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      className="saved-configs__name"
+                      onClick={() => void handleLoad(cfg)}
+                    >
+                      {cfg.name}
+                    </button>
+                  )}
+                  <div className="saved-configs__meta">
+                    {componentCount}/{CATEGORIES.length} composants · maj {formatDate(cfg.updated_at)}
+                  </div>
+                </div>
+                <div className="saved-configs__actions">
+                  <button type="button" className="saved-configs__btn" onClick={() => void handleLoad(cfg)}>
+                    Charger
+                  </button>
+                  <button type="button" className="saved-configs__btn" onClick={() => startRename(cfg)}>
+                    Renommer
+                  </button>
+                  <button
+                    type="button"
+                    className="saved-configs__btn saved-configs__btn--danger"
+                    onClick={() => void handleDelete(cfg)}
+                  >
+                    Supprimer
+                  </button>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </Modal>
+  )
+}
+
+export default SavedConfigsModal

--- a/src/services/__tests__/savedConfigs.service.test.ts
+++ b/src/services/__tests__/savedConfigs.service.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { savedConfigsService } from '../savedConfigs.service'
+
+interface QueryResult {
+  data: unknown
+  error: { message: string } | null
+}
+
+let queue: QueryResult[] = []
+let currentUserId: string | null = 'user-1'
+
+const calls: { table: string; ops: string[] }[] = []
+
+function makeBuilder(table: string) {
+  const entry = { table, ops: [] as string[] }
+  calls.push(entry)
+  const builder = {
+    select: vi.fn((cols?: string) => {
+      entry.ops.push(`select(${cols ?? '*'})`)
+      return builder
+    }),
+    insert: vi.fn((payload: unknown) => {
+      entry.ops.push(`insert(${JSON.stringify(payload)})`)
+      return builder
+    }),
+    update: vi.fn((payload: unknown) => {
+      entry.ops.push(`update(${JSON.stringify(payload)})`)
+      return builder
+    }),
+    delete: vi.fn(() => {
+      entry.ops.push('delete')
+      return builder
+    }),
+    eq: vi.fn((c: string, v: unknown) => {
+      entry.ops.push(`eq(${c}=${String(v)})`)
+      return builder
+    }),
+    in: vi.fn((c: string, v: unknown[]) => {
+      entry.ops.push(`in(${c}=${JSON.stringify(v)})`)
+      return builder
+    }),
+    order: vi.fn(() => builder),
+    single: vi.fn(() => Promise.resolve(queue.shift() ?? { data: null, error: null })),
+    then(resolve: (r: QueryResult) => void) {
+      return Promise.resolve(queue.shift() ?? { data: null, error: null }).then(resolve)
+    },
+  }
+  return builder
+}
+
+vi.mock('../../config', () => ({
+  supabase: {
+    from: (t: string) => makeBuilder(t),
+    auth: {
+      getUser: () =>
+        Promise.resolve({
+          data: { user: currentUserId ? { id: currentUserId } : null },
+        }),
+    },
+  },
+}))
+
+beforeEach(() => {
+  queue = []
+  calls.length = 0
+  currentUserId = 'user-1'
+})
+
+describe('savedConfigsService', () => {
+  it('list — returns sorted configs', async () => {
+    queue = [
+      {
+        data: [
+          { id: 'c1', name: 'Gaming', components: {}, created_at: 't1', updated_at: 't2' },
+        ],
+        error: null,
+      },
+    ]
+    const { data, error } = await savedConfigsService.list()
+    expect(error).toBeNull()
+    expect(data).toHaveLength(1)
+    expect(data[0].name).toBe('Gaming')
+    expect(calls[0].table).toBe('saved_configs')
+  })
+
+  it('create — inserts with current user id and trimmed name', async () => {
+    queue = [
+      { data: { id: 'c1', name: 'Workstation', components: { cpu: 'p1' }, created_at: 't', updated_at: 't' }, error: null },
+    ]
+    const { data, error } = await savedConfigsService.create('  Workstation  ', { cpu: 'p1' })
+    expect(error).toBeNull()
+    expect(data?.name).toBe('Workstation')
+    expect(calls[0].ops.some((o) => o.startsWith('insert'))).toBe(true)
+    expect(calls[0].ops[0]).toContain('"user_id":"user-1"')
+    expect(calls[0].ops[0]).toContain('"name":"Workstation"')
+  })
+
+  it('create — fails when user is not authenticated', async () => {
+    currentUserId = null
+    const { data, error } = await savedConfigsService.create('Test', { cpu: 'p1' })
+    expect(data).toBeNull()
+    expect(error).toBe('Utilisateur non connecté')
+  })
+
+  it('rename — updates by id with trimmed name', async () => {
+    queue = [{ data: null, error: null }]
+    const { error } = await savedConfigsService.rename('c1', '  New Name  ')
+    expect(error).toBeNull()
+    expect(calls[0].ops).toContainEqual('update({"name":"New Name"})')
+    expect(calls[0].ops).toContain('eq(id=c1)')
+  })
+
+  it('delete — calls delete with id', async () => {
+    queue = [{ data: null, error: null }]
+    const { error } = await savedConfigsService.delete('c1')
+    expect(error).toBeNull()
+    expect(calls[0].ops).toContain('delete')
+    expect(calls[0].ops).toContain('eq(id=c1)')
+  })
+
+  it('hydrate — re-fetches products and flags missing ones', async () => {
+    queue = [
+      {
+        data: [
+          { id: 'p1', name: 'CPU 1', manufacturer: 'X', series: null, variant: null, release_year: null, category: 'cpu', image_url: null, description: null, price_min_eur: null, price_max_eur: null, price_avg_eur: null, price_updated_at: null, retailer_url: null, benchmark_score: null },
+        ],
+        error: null,
+      },
+    ]
+    const result = await savedConfigsService.hydrate({
+      id: 'c1',
+      name: 'Test',
+      components: { cpu: 'p1', motherboard: 'deleted' },
+      created_at: 't',
+      updated_at: 't',
+    })
+    expect(result.products.cpu?.id).toBe('p1')
+    expect(result.missing).toEqual(['motherboard'])
+  })
+
+  it('hydrate — returns empty products when components is empty', async () => {
+    const result = await savedConfigsService.hydrate({
+      id: 'c1',
+      name: 'Empty',
+      components: {},
+      created_at: 't',
+      updated_at: 't',
+    })
+    expect(result.products).toEqual({})
+    expect(result.missing).toEqual([])
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,5 @@
 export { authService } from './auth.service'
 export { adminService } from './admin.service'
 export type { AdminUser, AdminProduct, DashboardStats } from './admin.service'
+export { savedConfigsService } from './savedConfigs.service'
+export type { SavedConfig, SavedConfigWithProducts } from './savedConfigs.service'

--- a/src/services/savedConfigs.service.ts
+++ b/src/services/savedConfigs.service.ts
@@ -1,0 +1,94 @@
+import { supabase } from '../config'
+import type { CategoryKey, Product } from '../types'
+
+export interface SavedConfig {
+  id: string
+  name: string
+  components: Partial<Record<CategoryKey, string>>
+  created_at: string
+  updated_at: string
+}
+
+export interface SavedConfigWithProducts extends SavedConfig {
+  products: Partial<Record<CategoryKey, Product>>
+  missing: CategoryKey[]
+}
+
+export const savedConfigsService = {
+  async list(): Promise<{ data: SavedConfig[]; error: string | null }> {
+    const { data, error } = await supabase
+      .from('saved_configs')
+      .select('id, name, components, created_at, updated_at')
+      .order('updated_at', { ascending: false })
+
+    if (error) return { data: [], error: error.message }
+    return { data: (data ?? []) as SavedConfig[], error: null }
+  },
+
+  async create(
+    name: string,
+    components: Partial<Record<CategoryKey, string>>,
+  ): Promise<{ data: SavedConfig | null; error: string | null }> {
+    const { data: userData } = await supabase.auth.getUser()
+    const userId = userData.user?.id
+    if (!userId) return { data: null, error: 'Utilisateur non connecté' }
+
+    const { data, error } = await supabase
+      .from('saved_configs')
+      .insert({ user_id: userId, name: name.trim(), components })
+      .select('id, name, components, created_at, updated_at')
+      .single()
+
+    if (error) return { data: null, error: error.message }
+    return { data: data as SavedConfig, error: null }
+  },
+
+  async rename(id: string, name: string): Promise<{ error: string | null }> {
+    const { error } = await supabase
+      .from('saved_configs')
+      .update({ name: name.trim() })
+      .eq('id', id)
+    return { error: error?.message ?? null }
+  },
+
+  async delete(id: string): Promise<{ error: string | null }> {
+    const { error } = await supabase.from('saved_configs').delete().eq('id', id)
+    return { error: error?.message ?? null }
+  },
+
+  /**
+   * Recharge une config : re-fetch chaque produit par son id, distingue les manquants
+   * (produit supprimé ou inaccessible) des présents.
+   */
+  async hydrate(config: SavedConfig): Promise<SavedConfigWithProducts> {
+    const ids = Object.values(config.components).filter(Boolean) as string[]
+    if (ids.length === 0) {
+      return { ...config, products: {}, missing: [] }
+    }
+
+    const { data, error } = await supabase
+      .from('products')
+      .select(
+        'id, name, manufacturer, series, variant, release_year, category, image_url, description, price_min_eur, price_max_eur, price_avg_eur, price_updated_at, retailer_url, benchmark_score',
+      )
+      .in('id', ids)
+
+    const byId = new Map<string, Product>()
+    if (!error && data) {
+      for (const p of data) {
+        byId.set(p.id, { ...(p as Product), specs: null })
+      }
+    }
+
+    const products: Partial<Record<CategoryKey, Product>> = {}
+    const missing: CategoryKey[] = []
+    for (const [cat, pid] of Object.entries(config.components) as [CategoryKey, string][]) {
+      if (!pid) continue
+      const prod = byId.get(pid)
+      if (prod) products[cat] = prod
+      else missing.push(cat)
+    }
+
+    return { ...config, products, missing }
+  },
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,8 +10,13 @@ interface ConfigStore {
   config: Partial<Record<CategoryKey, Product>>
   /** Dernière cascade d'invalidation (catégories retirées automatiquement). */
   lastInvalidated: CategoryKey[]
+  /** Id de la config chargée depuis Supabase (null si config locale non sauvegardée). */
+  loadedConfigId: string | null
+  loadedConfigName: string | null
   selectComponent: (category: CategoryKey, product: Product) => void
   removeComponent: (category: CategoryKey) => void
+  loadConfig: (id: string, name: string, products: Partial<Record<CategoryKey, Product>>) => void
+  setLoadedConfigName: (name: string) => void
   clearInvalidated: () => void
   clearConfig: () => void
 }
@@ -21,6 +26,8 @@ export const useConfigStore = create<ConfigStore>()(
     (set) => ({
       config: {},
       lastInvalidated: [],
+      loadedConfigId: null,
+      loadedConfigName: null,
       selectComponent: (category, product) =>
         set((state) => {
           const next: Partial<Record<CategoryKey, Product>> = { ...state.config, [category]: product }
@@ -36,12 +43,19 @@ export const useConfigStore = create<ConfigStore>()(
           for (const cat of invalidated) delete next[cat]
           return { config: next, lastInvalidated: invalidated }
         }),
+      loadConfig: (id, name, products) =>
+        set({ config: products, lastInvalidated: [], loadedConfigId: id, loadedConfigName: name }),
+      setLoadedConfigName: (name) => set({ loadedConfigName: name }),
       clearInvalidated: () => set({ lastInvalidated: [] }),
-      clearConfig: () => set({ config: {}, lastInvalidated: [] }),
+      clearConfig: () => set({ config: {}, lastInvalidated: [], loadedConfigId: null, loadedConfigName: null }),
     }),
     {
       name: 'pc-aeris-config',
-      partialize: (state) => ({ config: state.config }),
+      partialize: (state) => ({
+        config: state.config,
+        loadedConfigId: state.loadedConfigId,
+        loadedConfigName: state.loadedConfigName,
+      }),
     },
   ),
 )

--- a/supabase/migrations/20260522_saved_configs.sql
+++ b/supabase/migrations/20260522_saved_configs.sql
@@ -1,0 +1,54 @@
+-- Sprint 5 — US-041 à US-044 : sauvegarde des configurations utilisateur.
+-- Stocke uniquement les product_id (les détails sont re-fetchés au chargement).
+
+create table if not exists public.saved_configs (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  name        text not null check (char_length(trim(name)) between 1 and 80),
+  components  jsonb not null default '{}'::jsonb,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create index if not exists saved_configs_user_id_idx on public.saved_configs(user_id);
+create index if not exists saved_configs_updated_at_idx on public.saved_configs(updated_at desc);
+
+-- Trigger pour maintenir updated_at automatiquement.
+create or replace function public.touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists saved_configs_set_updated_at on public.saved_configs;
+create trigger saved_configs_set_updated_at
+  before update on public.saved_configs
+  for each row execute function public.touch_updated_at();
+
+-- RLS : chaque user ne voit/modifie que ses propres configs.
+alter table public.saved_configs enable row level security;
+
+drop policy if exists saved_configs_select_own on public.saved_configs;
+create policy saved_configs_select_own
+  on public.saved_configs for select
+  using (auth.uid() = user_id);
+
+drop policy if exists saved_configs_insert_own on public.saved_configs;
+create policy saved_configs_insert_own
+  on public.saved_configs for insert
+  with check (auth.uid() = user_id);
+
+drop policy if exists saved_configs_update_own on public.saved_configs;
+create policy saved_configs_update_own
+  on public.saved_configs for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+drop policy if exists saved_configs_delete_own on public.saved_configs;
+create policy saved_configs_delete_own
+  on public.saved_configs for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
## Sprint 5 — Groupe A : configs sauvegardées

Implémente les 5 user stories liées à la sauvegarde de configurations utilisateur :

- **US-041** — Sauvegarder une configuration (utilisateur connecté)
- **US-042** — Nommer une configuration sauvegardée
- **US-043** — Accéder à ses configurations sauvegardées
- **US-044** — Supprimer une configuration sauvegardée
- **US-040** — Indicateur de complétude de la configuration

## Changements

### Backend
- Migration Supabase \`supabase/migrations/20260522_saved_configs.sql\` :
  - Table \`saved_configs\` avec colonnes \`id\`, \`user_id\`, \`name\`, \`components (jsonb)\`, timestamps
  - RLS strict : chaque utilisateur ne voit/modifie que ses propres configs
  - Trigger \`touch_updated_at\` pour maintenir \`updated_at\` à jour
  - Index sur \`user_id\` et \`updated_at\`

### Frontend
- \`src/services/savedConfigs.service.ts\` : list / create / rename / delete / hydrate
- \`src/store/index.ts\` : ajout de \`loadConfig\`, \`loadedConfigId\`, \`loadedConfigName\`
- Modal \`SavedConfigsModal\` accessible depuis la sidebar du configurateur
- Boutons \"💾 Sauvegarder\" et \"Mes configs\" (visibles uniquement si connecté)
- Indicateur \"✓ Configuration complète\" quand 8/8 composants sont sélectionnés
- Hint discret \"Connecte-toi pour sauvegarder\" pour les visiteurs non auth
- Hydratation tolérante : si un produit est supprimé en base, l'utilisateur est notifié via toast

## Décisions de design

- **Stockage par ID uniquement** (pas de snapshot) : les configs reflètent automatiquement les mises à jour produit (prix, image). Trade-off : si un produit est supprimé, l'entrée correspondante disparaît de la config rechargée.
- **Modal in-place** plutôt que page dédiée : moins de navigation, contexte conservé.
- **Création seulement, pas d'update** : \"Sauvegarder\" crée toujours une nouvelle entrée. Pour mettre à jour, l'utilisateur supprime l'ancienne. UX simple pour Sprint 5.

## Tests

- 7 nouveaux tests sur \`savedConfigsService\` (list, create, rename, delete, hydrate avec produits manquants)
- **Total : 67 tests verts**, tsc clean, eslint clean, build OK

## Action requise après merge

⚠️ **Appliquer la migration Supabase** via le dashboard ou la CLI :
\`\`\`bash
supabase db push
\`\`\`
ou copier-coller le contenu de \`supabase/migrations/20260522_saved_configs.sql\` dans l'éditeur SQL Supabase.

## Test plan

- [ ] Appliquer la migration en base
- [ ] Se connecter, configurer un PC partiel, cliquer \"Sauvegarder\" → toast de succès
- [ ] Ouvrir \"Mes configs\" → la config apparaît
- [ ] Cliquer sur le nom ou \"Charger\" → la config se charge dans le configurateur
- [ ] Renommer une config inline → mise à jour visible
- [ ] Supprimer une config → confirmation + disparition
- [ ] Compléter les 8 catégories → badge \"Configuration complète\" affiché
- [ ] Vérifier qu'un visiteur non connecté voit le hint d'invitation à se connecter

## Dépendance

Cette PR est basée sur \`fix/configurator-selection-order\` (#164). Elle inclut donc les commits de la cascade d'invalidation. Si #164 est mergée d'abord dans \`develop\`, le rebase sera trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)