### PR TITLE
feat(sprint-5): remember me, tarifs assemblage, responsive admin

### DIFF
--- a/src/components/layout/AdminLayout/AdminLayout.scss
+++ b/src/components/layout/AdminLayout/AdminLayout.scss
@@ -6,6 +6,10 @@
   display: grid;
   grid-template-columns: 248px 1fr;
   min-height: calc(100vh - var(--nav-h));
+
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr;
+  }
 }
 
 // ── ADMIN SIDEBAR ──────────────────────────────────────────────────────────
@@ -19,6 +23,29 @@
   top: var(--nav-h);
   height: calc(100vh - var(--nav-h));
   overflow: hidden;
+
+  @media (max-width: 900px) {
+    position: relative;
+    top: auto;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: hidden;
+
+    &__hd { display: none; }
+    &__body {
+      display: flex;
+      flex-direction: row;
+      padding: 0;
+    }
+    &__section { display: none; }
+    &__item {
+      white-space: nowrap;
+      padding: 14px 18px;
+    }
+  }
 
   &__hd {
     padding: 24px 24px 20px;
@@ -166,6 +193,14 @@
   flex-shrink: 0;
   gap: 16px;
 
+  @media (max-width: 640px) {
+    padding: 20px 18px 16px;
+    flex-direction: column;
+    align-items: stretch;
+
+    &__ghost { font-size: 64px; right: -8px; bottom: -16px; }
+  }
+
   &__ghost {
     position: absolute;
     right: -12px;
@@ -213,6 +248,10 @@
 .admin-body {
   padding: 28px 36px;
   flex: 1;
+
+  @media (max-width: 640px) {
+    padding: 18px;
+  }
 }
 
 // ── STAT CARDS ─────────────────────────────────────────────────────────────
@@ -427,7 +466,10 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--rl);
-  overflow: hidden;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+
+  // Sur petit écran, le tableau peut être plus large que l'écran et scroller horizontalement.
 }
 
 .ad-table {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,1 +1,1 @@
-export { supabase } from './supabase'
+export { supabase, setRememberMe } from './supabase'

--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -7,4 +7,48 @@ if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase environment variables')
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+/**
+ * Remember-me flag (US-016) :
+ * Si activé, la session est persistée dans localStorage (par défaut Supabase).
+ * Sinon, on bascule sur sessionStorage : la session expire à la fermeture du
+ * navigateur. Le flag est lui-même conservé dans localStorage pour survivre aux
+ * rechargements de page.
+ */
+const REMEMBER_KEY = 'pc-aeris-remember-session'
+
+export function setRememberMe(value: boolean) {
+  if (typeof window === 'undefined') return
+  if (value) window.localStorage.setItem(REMEMBER_KEY, 'true')
+  else window.localStorage.removeItem(REMEMBER_KEY)
+}
+
+function shouldRemember(): boolean {
+  if (typeof window === 'undefined') return true
+  return window.localStorage.getItem(REMEMBER_KEY) === 'true'
+}
+
+const switchableStorage = {
+  getItem: (key: string): string | null => {
+    if (typeof window === 'undefined') return null
+    const store = shouldRemember() ? window.localStorage : window.sessionStorage
+    return store.getItem(key)
+  },
+  setItem: (key: string, value: string): void => {
+    if (typeof window === 'undefined') return
+    const store = shouldRemember() ? window.localStorage : window.sessionStorage
+    store.setItem(key, value)
+  },
+  removeItem: (key: string): void => {
+    if (typeof window === 'undefined') return
+    window.localStorage.removeItem(key)
+    window.sessionStorage.removeItem(key)
+  },
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    storage: switchableStorage,
+    persistSession: true,
+    autoRefreshToken: true,
+  },
+})

--- a/src/pages/Home/Home.scss
+++ b/src/pages/Home/Home.scss
@@ -656,3 +656,125 @@
   }
 }
 
+// ── US-004 — Tarifs d'assemblage ─────────────────────────────────────────
+.assembly {
+  background: var(--bg);
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 18px;
+    margin-top: 56px;
+
+    @media (max-width: 900px) { grid-template-columns: 1fr; }
+  }
+
+  &__tier {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--rl);
+    padding: 36px 28px;
+    position: relative;
+    transition: transform 0.2s var(--ease), border-color 0.2s;
+    display: flex;
+    flex-direction: column;
+
+    &:hover {
+      border-color: var(--border-s);
+      transform: translateY(-3px);
+    }
+
+    &--hl {
+      border-color: var(--ind);
+      background: linear-gradient(180deg, rgba(99,102,241,0.05) 0%, var(--surface) 60%);
+    }
+  }
+
+  &__badge {
+    position: absolute;
+    top: -10px;
+    left: 28px;
+    background: var(--ind);
+    color: #fff;
+    font-family: var(--fm);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    padding: 4px 10px;
+    border-radius: 100px;
+  }
+
+  &__name {
+    font-family: var(--fh);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-2);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 18px;
+  }
+
+  &__price {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+
+  &__price-from {
+    font-family: var(--fm);
+    font-size: 10px;
+    color: var(--text-3);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+
+  &__price-val {
+    font-family: var(--fh);
+    font-size: 42px;
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    color: var(--text);
+  }
+
+  &__desc {
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text-2);
+    margin-bottom: 24px;
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0 0 8px 0;
+    padding: 0;
+    flex: 1;
+
+    li {
+      font-size: 13px;
+      line-height: 1.6;
+      color: var(--text-2);
+      padding-left: 22px;
+      margin-bottom: 8px;
+      position: relative;
+
+      &::before {
+        content: '✓';
+        position: absolute;
+        left: 0;
+        top: 0;
+        color: var(--ind);
+        font-weight: 600;
+      }
+    }
+  }
+
+  &__note {
+    font-family: var(--fm);
+    font-size: 11px;
+    color: var(--text-3);
+    text-align: center;
+    margin-top: 28px;
+    letter-spacing: 0.04em;
+  }
+}
+

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -392,6 +392,88 @@ function How() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// US-004 — Tarifs indicatifs d'assemblage
+// Affichés à titre indicatif. Tarifs ajustables côté business sans déploiement
+// en remontant les valeurs dans un futur CMS / table de config.
+
+const ASSEMBLY_TIERS = [
+  {
+    name: 'Essentiel',
+    price: 79,
+    desc: 'Montage standard, vérification fonctionnelle, test de boot.',
+    includes: ['Montage des composants', 'Câble management de base', 'Test POST + démarrage Windows'],
+  },
+  {
+    name: 'Confort',
+    price: 129,
+    desc: 'Montage soigné, optimisation thermique, installation OS et drivers.',
+    includes: [
+      'Tout l\'offre Essentiel',
+      'Câble management premium',
+      'Installation Windows + drivers à jour',
+      'Profil de courbes ventilateurs',
+    ],
+    highlight: true,
+  },
+  {
+    name: 'Premium',
+    price: 199,
+    desc: 'Tuning complet, benchmarks, profil overclock léger si compatible.',
+    includes: [
+      'Tout l\'offre Confort',
+      'Benchmarks 3DMark + Cinebench',
+      'Profil XMP / EXPO + courbes optimisées',
+      'Rapport de tests délivré au client',
+    ],
+  },
+]
+
+function AssemblyPricing() {
+  return (
+    <section className="s assembly" id="tarifs-assemblage">
+      <div className="c">
+        <div className="chmark rv">
+          <span className="chmark__n">04 / TARIFS</span>
+          <span className="chmark__line" />
+        </div>
+        <div className="s__head">
+          <h2 className="s__h2 rv">Tarifs<br />d&apos;assemblage</h2>
+          <p className="s__p rv s__p--right">
+            Forfaits indicatifs pour l&apos;assemblage et la mise en service de votre configuration. Le devis final est ajusté selon la complexité.
+          </p>
+        </div>
+
+        <div className="assembly__grid">
+          {ASSEMBLY_TIERS.map((tier, i) => (
+            <article
+              key={tier.name}
+              className={`assembly__tier rv rv-d${i + 1} ${tier.highlight ? 'assembly__tier--hl' : ''}`}
+            >
+              {tier.highlight && <span className="assembly__badge">Recommandé</span>}
+              <div className="assembly__name">{tier.name}</div>
+              <div className="assembly__price">
+                <span className="assembly__price-from">à partir de</span>
+                <span className="assembly__price-val">{tier.price}€</span>
+              </div>
+              <p className="assembly__desc">{tier.desc}</p>
+              <ul className="assembly__list">
+                {tier.includes.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+
+        <p className="assembly__note rv">
+          Les tarifs sont indicatifs et hors composants. Un devis personnalisé est établi après validation de votre configuration.
+        </p>
+      </div>
+    </section>
+  )
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 
 function Home() {
   const stats = usePublicStats()
@@ -402,6 +484,7 @@ function Home() {
       <Stats stats={stats} />
       <Bento stats={stats} />
       <How />
+      <AssemblyPricing />
     </>
   )
 }

--- a/src/pages/auth/SignIn.tsx
+++ b/src/pages/auth/SignIn.tsx
@@ -28,6 +28,7 @@ function SignIn() {
     const { user, error: authError } = await signIn({
       identifier: form.identifier,
       password: form.password,
+      rememberMe: form.rememberMe,
     })
     if (authError) {
       setError(authError)

--- a/src/services/__tests__/auth.integration.test.ts
+++ b/src/services/__tests__/auth.integration.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../config', () => ({
     auth: { signInWithPassword },
     rpc,
   },
+  setRememberMe: vi.fn(),
 }))
 
 import { authService } from '../auth.service'

--- a/src/services/__tests__/auth.service.test.ts
+++ b/src/services/__tests__/auth.service.test.ts
@@ -3,6 +3,7 @@ import { validateSignUpData } from '../auth.service'
 
 vi.mock('../../config', () => ({
   supabase: { auth: {}, rpc: vi.fn() },
+  setRememberMe: vi.fn(),
 }))
 
 describe('validateSignUpData', () => {

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,5 +1,4 @@
-import { supabase } from '../config'
-import { setRememberMe } from '../config/supabase'
+import { supabase, setRememberMe } from '../config'
 import type { SignUpData, SignInData, User } from '../types'
 
 // Admin credentials (hardcoded for now)

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../config'
+import { setRememberMe } from '../config/supabase'
 import type { SignUpData, SignInData, User } from '../types'
 
 // Admin credentials (hardcoded for now)
@@ -74,8 +75,12 @@ export const authService = {
 
   // Sign in with email or pseudo and password
   async signIn(data: SignInData): Promise<{ user: User | null; error: string | null }> {
+    // Doit être appelé AVANT signInWithPassword pour que Supabase écrive la
+    // session dans le bon storage (local vs session).
+    setRememberMe(Boolean(data.rememberMe))
+
     let email = data.identifier
-    
+
     // If identifier is not an email, it's a pseudo - need to find the email
     if (!isEmail(data.identifier)) {
       // Check if it's the admin
@@ -122,6 +127,8 @@ export const authService = {
   // Sign out
   async signOut(): Promise<{ error: string | null }> {
     const { error } = await supabase.auth.signOut()
+    // On efface aussi le flag remember pour repartir d'un état propre.
+    setRememberMe(false)
     return { error: error?.message || null }
   },
 

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -30,6 +30,7 @@ export interface SignUpData {
 export interface SignInData {
   identifier: string // email or pseudo
   password: string
+  rememberMe?: boolean
 }
 
 export interface AuthError {


### PR DESCRIPTION
## Sprint 5 — reste à livrer pour clore le MVP

### Stories effectivement implémentées dans cette PR

**US-016 — Remember me (logique branchée)**
- Storage Supabase rendu commutable (localStorage ↔ sessionStorage) selon le flag \`pc-aeris-remember-session\`
- \`signIn\` accepte désormais \`rememberMe\` et configure le storage *avant* l'appel à Supabase pour que la session soit persistée au bon endroit
- \`signOut\` nettoie le flag
- Comportement : si décoché, la session expire à la fermeture du navigateur ; si coché, elle persiste

**US-004 — Tarifs indicatifs d'assemblage**
- Nouvelle section \`AssemblyPricing\` sur la home, après \`How\`
- 3 forfaits affichés en cards : Essentiel (79€) / Confort (129€, recommandé) / Premium (199€)
- Liste des prestations incluses par forfait, badge \"Recommandé\", note disclaimer

**US-006 — Responsive mobile (admin + audit global)**
- AdminLayout : sidebar 248px passe en *tab-bar horizontale scrollable* en dessous de 900px
- Tableaux admin (Users, Products) : overflow-x auto pour rester utilisables à 375px
- admin-hd : stack vertical à partir de 640px, ghost label réduit
- admin-body : padding réduit sur mobile
- Audit du reste : Home, Configurator, Auth, ProductDetail, Profile ont déjà leurs breakpoints

### Stories Sprint 5 vérifiées et déjà livrées (rien à coder)

| Story | État |
|---|---|
| US-030 — Images composants dans la liste configurateur | ✅ déjà présent dans le code |
| US-074 — Recherche et filtre utilisateurs admin | ✅ déjà fait (input search avec filtre sur email/pseudo/prénom/nom) |
| US-063 — Modification du pseudo depuis le profil | ✅ déjà fait dans Profile.tsx |
| US-064 — Changement de mot de passe depuis le profil | ✅ déjà fait dans Profile.tsx |

### Stories Sprint 5 toujours bloquées

| Story | Bloqueur |
|---|---|
| US-010, US-028, US-039 — Affichage UI prix catalogue/configurateur/total | UI partielle prête (currency display, fallback prix non disponible). Branchement effectif des sources de prix bloqué par credentials API non obtenus. |

## Validation

- ✅ \`npx tsc -b\` clean
- ✅ \`npx eslint src\` clean
- ✅ 60 tests verts
- ✅ \`npx vite build\` OK

## Test plan

- [ ] Se connecter avec \"Se souvenir de moi\" coché → fermer le navigateur → rouvrir → la session est conservée
- [ ] Se déconnecter et reconnecter avec \"Se souvenir de moi\" décoché → fermer l'onglet → rouvrir → l'utilisateur est déconnecté
- [ ] Charger la home et descendre jusqu'à la section \"Tarifs d'assemblage\" → 3 cards visibles
- [ ] Ouvrir \`/admin\` sur mobile (375px) → la sidebar passe en barre horizontale, le tableau scrolle horizontalement

🤖 Generated with [Claude Code](https://claude.com/claude-code)