### PR TITLE
fix(admin): sidebar pleine hauteur, drawer mobile, diagnostic vide/erreur

### DIFF
--- a/src/components/layout/AdminLayout/AdminLayout.scss
+++ b/src/components/layout/AdminLayout/AdminLayout.scss
@@ -5,7 +5,6 @@
 .admin-wrap {
   display: grid;
   grid-template-columns: 248px 1fr;
-  min-height: calc(100vh - var(--nav-h));
 
   @media (max-width: 900px) {
     grid-template-columns: 1fr;
@@ -13,43 +12,24 @@
 }
 
 // ── ADMIN SIDEBAR ──────────────────────────────────────────────────────────
+//
+// Desktop : la sidebar est dans la colonne 1 du grid, en position sticky pour
+// suivre le scroll. Sa hauteur est calc(100vh - var(--nav-h)) pour rester
+// pleine hauteur même quand le contenu est plus long.
+//
+// Mobile : la sidebar n'est plus dans le grid. Elle est remplacée par un drawer
+// (cf. .admin-drawer / .admin-nav--mobile ci-dessous) déclenché par le bouton
+// hamburger dans .admin-hd__burger.
 
 .admin-nav {
   background: var(--surface);
-  border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
-  position: sticky;
-  top: var(--nav-h);
-  height: calc(100vh - var(--nav-h));
-  overflow: hidden;
-
-  @media (max-width: 900px) {
-    position: relative;
-    top: auto;
-    height: auto;
-    border-right: none;
-    border-bottom: 1px solid var(--border);
-    flex-direction: row;
-    overflow-x: auto;
-    overflow-y: hidden;
-
-    &__hd { display: none; }
-    &__body {
-      display: flex;
-      flex-direction: row;
-      padding: 0;
-    }
-    &__section { display: none; }
-    &__item {
-      white-space: nowrap;
-      padding: 14px 18px;
-    }
-  }
 
   &__hd {
     padding: 24px 24px 20px;
     border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
   }
 
   &__label {
@@ -74,6 +54,7 @@
     flex: 1;
     padding: 12px 0;
     overflow-y: auto;
+    min-height: 0;
   }
 
   &__section {
@@ -127,6 +108,7 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
+    flex-shrink: 0;
   }
 
   &__who {
@@ -171,6 +153,79 @@
 
     &:hover { color: var(--text-2); }
   }
+
+  // Variante desktop : colonne 1 du grid, sticky pleine hauteur.
+  &--desktop {
+    border-right: 1px solid var(--border);
+    position: sticky;
+    top: var(--nav-h);
+    height: calc(100vh - var(--nav-h));
+
+    @media (max-width: 900px) {
+      display: none;
+    }
+  }
+
+  // Variante mobile (utilisée dans le drawer) : pleine hauteur, scrollable.
+  &--mobile {
+    height: 100%;
+    width: 100%;
+    max-width: 320px;
+  }
+}
+
+// ── DRAWER MOBILE ──────────────────────────────────────────────────────────
+
+.admin-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+
+  @media (min-width: 901px) {
+    display: none;
+  }
+
+  &__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+  }
+
+  &__close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 1;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover { background: var(--surface); }
+  }
+
+  .admin-nav {
+    position: relative;
+    z-index: 1;
+    box-shadow: 4px 0 32px rgba(0, 0, 0, 0.5);
+    animation: admin-drawer-in 0.22s ease-out;
+  }
+}
+
+@keyframes admin-drawer-in {
+  from { transform: translateX(-100%); }
+  to   { transform: translateX(0); }
 }
 
 // ── ADMIN CONTENT ──────────────────────────────────────────────────────────
@@ -193,12 +248,49 @@
   flex-shrink: 0;
   gap: 16px;
 
-  @media (max-width: 640px) {
+  @media (max-width: 900px) {
     padding: 20px 18px 16px;
-    flex-direction: column;
-    align-items: stretch;
+    align-items: center;
+  }
 
+  @media (max-width: 640px) {
+    flex-wrap: wrap;
     &__ghost { font-size: 64px; right: -8px; bottom: -16px; }
+  }
+
+  &__burger {
+    display: none;
+    width: 38px;
+    height: 38px;
+    border-radius: 8px;
+    background: transparent;
+    border: 1px solid var(--border);
+    cursor: pointer;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    margin-right: 4px;
+    flex-shrink: 0;
+    position: relative;
+    z-index: 2;
+    transition: border-color 0.13s, background 0.13s;
+
+    &:hover {
+      border-color: var(--border-s);
+      background: rgba(255, 255, 255, 0.03);
+    }
+
+    span {
+      width: 16px;
+      height: 1.5px;
+      background: var(--text);
+      border-radius: 1px;
+    }
+
+    @media (max-width: 900px) {
+      display: flex;
+    }
   }
 
   &__ghost {

--- a/src/components/layout/AdminLayout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout/AdminLayout.tsx
@@ -23,7 +23,10 @@ function AdminLayout({ children, title, eyebrow = 'Administration', ghost, actio
   const [drawerOpen, setDrawerOpen] = useState(false)
 
   // Ferme le drawer à chaque changement de route.
+  // setState dans un effect est ici intentionnel : on synchronise l'UI avec
+  // l'URL qui peut changer hors de notre contrôle (back/forward navigateur).
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDrawerOpen(false)
   }, [pathname])
 

--- a/src/components/layout/AdminLayout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout/AdminLayout.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router-dom'
-import { type ReactNode } from 'react'
+import { type ReactNode, useEffect, useState } from 'react'
 import { useAuth } from '../../../context'
 import './AdminLayout.scss'
 
@@ -20,46 +20,93 @@ interface AdminLayoutProps {
 function AdminLayout({ children, title, eyebrow = 'Administration', ghost, actions }: AdminLayoutProps) {
   const { pathname } = useLocation()
   const { user, signOut } = useAuth()
+  const [drawerOpen, setDrawerOpen] = useState(false)
+
+  // Ferme le drawer à chaque changement de route.
+  useEffect(() => {
+    setDrawerOpen(false)
+  }, [pathname])
+
+  // Empêche le scroll body quand drawer ouvert.
+  useEffect(() => {
+    if (drawerOpen) document.body.style.overflow = 'hidden'
+    else document.body.style.overflow = ''
+    return () => { document.body.style.overflow = '' }
+  }, [drawerOpen])
+
+  const sidebar = (
+    <>
+      <div className="admin-nav__hd">
+        <span className="admin-nav__label">PC Aeris</span>
+        <div className="admin-nav__title">Console Admin</div>
+      </div>
+
+      <div className="admin-nav__body">
+        <div className="admin-nav__section">Pilotage</div>
+        {NAV_ITEMS.map((it) => {
+          const active = pathname === it.to
+          return (
+            <Link
+              key={it.to}
+              to={it.to}
+              className={`admin-nav__item ${active ? 'admin-nav__item--act' : ''}`}
+              onClick={() => setDrawerOpen(false)}
+            >
+              <span className="admin-nav__item-ico">{it.icon}</span>
+              <span>{it.label}</span>
+            </Link>
+          )
+        })}
+      </div>
+
+      <div className="admin-nav__ft">
+        {user && (
+          <div className="admin-nav__who">
+            <div className="admin-nav__who-name">{user.pseudo || user.email}</div>
+            <div className="admin-nav__who-role">Administrateur</div>
+          </div>
+        )}
+        <Link to="/" className="admin-nav__back">← Retour au site</Link>
+        <button type="button" className="admin-nav__back" onClick={() => signOut()}>Déconnexion</button>
+      </div>
+    </>
+  )
 
   return (
     <div className="admin-wrap">
-      <aside className="admin-nav">
-        <div className="admin-nav__hd">
-          <span className="admin-nav__label">PC Aeris</span>
-          <div className="admin-nav__title">Console Admin</div>
-        </div>
-
-        <div className="admin-nav__body">
-          <div className="admin-nav__section">Pilotage</div>
-          {NAV_ITEMS.map((it) => {
-            const active = pathname === it.to
-            return (
-              <Link
-                key={it.to}
-                to={it.to}
-                className={`admin-nav__item ${active ? 'admin-nav__item--act' : ''}`}
-              >
-                <span className="admin-nav__item-ico">{it.icon}</span>
-                <span>{it.label}</span>
-              </Link>
-            )
-          })}
-        </div>
-
-        <div className="admin-nav__ft">
-          {user && (
-            <div className="admin-nav__who">
-              <div className="admin-nav__who-name">{user.pseudo || user.email}</div>
-              <div className="admin-nav__who-role">Administrateur</div>
-            </div>
-          )}
-          <Link to="/" className="admin-nav__back">← Retour au site</Link>
-          <button className="admin-nav__back" onClick={() => signOut()}>Déconnexion</button>
-        </div>
+      {/* Sidebar desktop : toujours visible en grid à gauche. */}
+      <aside className="admin-nav admin-nav--desktop">
+        {sidebar}
       </aside>
+
+      {/* Drawer mobile : overlay + panneau slide-in à gauche. */}
+      {drawerOpen && (
+        <div className="admin-drawer">
+          <div className="admin-drawer__backdrop" onClick={() => setDrawerOpen(false)} />
+          <aside className="admin-nav admin-nav--mobile">
+            <button
+              type="button"
+              className="admin-drawer__close"
+              onClick={() => setDrawerOpen(false)}
+              aria-label="Fermer le menu"
+            >
+              ×
+            </button>
+            {sidebar}
+          </aside>
+        </div>
+      )}
 
       <div className="admin-content">
         <div className="admin-hd">
+          <button
+            type="button"
+            className="admin-hd__burger"
+            onClick={() => setDrawerOpen(true)}
+            aria-label="Ouvrir le menu admin"
+          >
+            <span /><span /><span />
+          </button>
           <div className="admin-hd__left">
             <div className="admin-hd__eyebrow">{eyebrow}</div>
             {title && <div className="admin-hd__title">{title}</div>}

--- a/src/pages/admin/Products.tsx
+++ b/src/pages/admin/Products.tsx
@@ -470,8 +470,31 @@ function AdminProducts() {
 
       {loading ? (
         <div className="ad-loading">Chargement…</div>
+      ) : error ? (
+        <div className="ad-empty-state">
+          <div style={{ textAlign: 'center', maxWidth: 480 }}>
+            <strong style={{ color: 'var(--text)' }}>Impossible de charger les produits.</strong>
+            <div style={{ marginTop: 8, fontSize: 12, fontFamily: 'var(--fm)', color: 'var(--text-3)' }}>
+              {error}
+            </div>
+            <div style={{ marginTop: 16, fontSize: 12, color: 'var(--text-3)', lineHeight: 1.6 }}>
+              Vérifie que la table <code>products</code> est accessible et que les RLS l'autorisent en lecture pour ton rôle.
+            </div>
+          </div>
+        </div>
+      ) : total === 0 && !search.trim() && category === 'all' ? (
+        <div className="ad-empty-state">
+          <div style={{ textAlign: 'center' }}>
+            <strong style={{ color: 'var(--text)' }}>Catalogue vide.</strong>
+            <div style={{ marginTop: 8, fontSize: 12, color: 'var(--text-3)' }}>
+              Importe des produits via les scripts <code>scripts/import-buildcores.mjs</code> ou crée-en depuis ce panneau.
+            </div>
+          </div>
+        </div>
       ) : products.length === 0 ? (
-        <div className="ad-empty-state">Aucun produit trouvé.</div>
+        <div className="ad-empty-state">
+          Aucun produit ne correspond aux filtres actuels.
+        </div>
       ) : (
         <div className="ad-table-wrap">
           <table className="ad-table">

--- a/src/pages/admin/Users.tsx
+++ b/src/pages/admin/Users.tsx
@@ -114,8 +114,29 @@ function AdminUsers() {
 
       {loading ? (
         <div className="ad-loading">Chargement…</div>
+      ) : error ? (
+        <div className="ad-empty-state">
+          <div style={{ textAlign: 'center', maxWidth: 480 }}>
+            <strong style={{ color: 'var(--text)' }}>Impossible de charger la liste des utilisateurs.</strong>
+            <div style={{ marginTop: 8, fontSize: 12, fontFamily: 'var(--fm)', color: 'var(--text-3)' }}>
+              {error}
+            </div>
+            <div style={{ marginTop: 16, fontSize: 12, color: 'var(--text-3)', lineHeight: 1.6 }}>
+              Vérifie que tu es connecté en tant qu'administrateur et que la fonction RPC <code>admin_list_users</code> est bien déployée côté Supabase.
+            </div>
+          </div>
+        </div>
+      ) : users.length === 0 ? (
+        <div className="ad-empty-state">
+          <div style={{ textAlign: 'center' }}>
+            <strong style={{ color: 'var(--text)' }}>Aucun utilisateur en base.</strong>
+            <div style={{ marginTop: 8, fontSize: 12, color: 'var(--text-3)' }}>
+              La table profiles est vide ou la RPC ne retourne rien.
+            </div>
+          </div>
+        </div>
       ) : filtered.length === 0 ? (
-        <div className="ad-empty-state">Aucun utilisateur trouvé.</div>
+        <div className="ad-empty-state">Aucun utilisateur ne correspond à « {search} ».</div>
       ) : (
         <div className="ad-table-wrap">
           <table className="ad-table">


### PR DESCRIPTION
## Soucis traités

1. **Sidebar admin desktop pas pleine hauteur** dans certaines configurations d'écran/contenu.
2. **Responsive catastrophique sur mobile** — la sidebar passait en barre horizontale scrollable, l'utilisateur ne comprenait pas l'organisation.
3. **Listes utilisateurs et produits vides sans diagnostic** — quand la RPC \`admin_list_users\` ou les RLS sur \`products\` échouent silencieusement, l'utilisateur voit juste un état vide sans explication.

## Solution

### Desktop : sidebar pleine hauteur garantie
- Restructuration du SCSS : \`.admin-nav\` porte tous les enfants BEM (hd/body/ft/item...). Les variants \`.admin-nav--desktop\` et \`.admin-nav--mobile\` portent uniquement le positionnement.
- Hauteur \`calc(100vh - var(--nav-h))\` avec \`position: sticky\` sur le variant desktop.
- \`flex-shrink: 0\` sur hd et ft, \`flex: 1\` + \`min-height: 0\` sur body — garantit que le body scrolle proprement sans casser la pleine hauteur.

### Mobile : drawer avec hamburger
- Bouton hamburger ajouté dans \`.admin-hd\` (visible uniquement < 901px).
- Drawer slide-in depuis la gauche avec backdrop flouté, fermeture par clic backdrop / sélection d'un lien / changement de route.
- Sidebar desktop masquée sous 901px, drawer affiché à la place.
- Anim CSS \`admin-drawer-in\` 220ms ease-out.

### Diagnostic vide/erreur
**Users.tsx** :
- Erreur RPC → message \"Impossible de charger la liste des utilisateurs\" avec détail du message d'erreur Supabase + rappel de vérifier la RPC \`admin_list_users\`
- Table vide sans erreur → \"Aucun utilisateur en base\" (la table profiles est vide)
- Recherche sans résultat → \"Aucun utilisateur ne correspond à « X »\"

**Products.tsx** :
- Erreur → \"Impossible de charger les produits\" avec rappel des RLS
- Catalogue vide (pas de filtre actif) → \"Catalogue vide\" + suggestion d'import via \`scripts/import-buildcores.mjs\`
- Filtres sans résultat → message contextuel

## Validation

- ✅ tsc clean
- ✅ eslint clean
- ✅ 67 tests passent
- ✅ vite build OK

## Test plan

- [ ] Aller sur \`/admin\` en desktop → la sidebar fait toute la hauteur viewport, le footer (\"Retour au site\", \"Déconnexion\") est visible en bas.
- [ ] Redimensionner < 900px → la sidebar disparaît, un bouton hamburger apparaît dans le header admin.
- [ ] Cliquer le hamburger → drawer slide-in depuis la gauche avec les 3 items + footer utilisateur.
- [ ] Cliquer hors du drawer ou sur un lien → fermeture.
- [ ] Aller sur \`/admin/users\` quand la RPC échoue → message d'erreur explicite avec rappel d'action.
- [ ] Aller sur \`/admin/products\` quand le catalogue est vide → message + suggestion d'import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)