### PR TITLE
fix(admin): sidebar desktop sticky en top:0

### DIFF
--- a/src/components/layout/AdminLayout/AdminLayout.scss
+++ b/src/components/layout/AdminLayout/AdminLayout.scss
@@ -158,7 +158,7 @@
   &--desktop {
     border-right: 1px solid var(--border);
     position: sticky;
-    top: var(--nav-h);
+    top: 0;
     height: 100vh;
 
     @media (max-width: 900px) {


### PR DESCRIPTION
Ajustement demandé : la sidebar admin était fixée à `top: var(--nav-h)` et donc commençait sous la barre de navigation principale. On passe à `top: 0` pour qu'elle remonte en haut du viewport et reste fixée correctement au scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)