### PR TITLE
fix(compatibility): boîtier et stockage ne disparaissent plus à tort

### DIFF
--- a/src/utils/__tests__/compatibility.integration.test.ts
+++ b/src/utils/__tests__/compatibility.integration.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { getCompatibleProductIds } from '../compatibility'
 import type { Product } from '../../types'
 
-type FromResponse = { data: { product_id: string; form_factor?: string }[] | null; error: null }
+type FromResponse = {
+  data: { product_id: string; form_factor?: string; supported_mobo_form_factors?: string[] | null }[] | null
+  error: null
+}
 
 const { state, makeBuilder } = vi.hoisted(() => {
   const state = {
@@ -17,6 +20,7 @@ const { state, makeBuilder } = vi.hoisted(() => {
       eq: vi.fn((c: string, v: unknown) => { entry.ops.push(`eq(${c}=${String(v)})`); return builder }),
       contains: vi.fn((c: string, v: unknown) => { entry.ops.push(`contains(${c}=${JSON.stringify(v)})`); return builder }),
       gte: vi.fn((c: string, v: unknown) => { entry.ops.push(`gte(${c}>=${String(v)})`); return builder }),
+      or: vi.fn((s: string) => { entry.ops.push(`or(${s})`); return builder }),
       then(resolve: (r: FromResponse) => void) {
         const r = state.queue.shift() ?? { data: [], error: null }
         return Promise.resolve(r).then(resolve)
@@ -91,11 +95,14 @@ describe('Configurator flow — chained compatibility filters', () => {
     expect(state.callLog[0].ops).toContainEqual('gte(wattage>=864)')
   })
 
-  it('ITX build: mobo (Mini ITX) selected → case filtered by form factor', async () => {
+  it('ITX build: mobo (Mini ITX) selected → case filtered en JS avec normalisation', async () => {
     const mobo = prod({ form_factor: 'Mini ITX', ram_type: 'DDR5' })
 
     state.queue = [{
-      data: [{ product_id: 'case-itx' }],
+      data: [
+        { product_id: 'case-itx', supported_mobo_form_factors: ['Mini-ITX'] }, // notation différente, doit matcher
+        { product_id: 'case-atx', supported_mobo_form_factors: ['ATX'] },
+      ],
       error: null,
     }]
 
@@ -103,17 +110,16 @@ describe('Configurator flow — chained compatibility filters', () => {
 
     expect(res.productIds).toEqual(['case-itx'])
     expect(state.callLog[0].table).toBe('pc_case_specs')
-    expect(state.callLog[0].ops).toContainEqual('contains(supported_mobo_form_factors=["Mini ITX"])')
     expect(res.reason).toContain('Mini ITX')
   })
 
-  it('SATA-only mobo: storage excludes NVMe', async () => {
+  it('SATA-only mobo: storage exclut NVMe mais accepte nvme=null', async () => {
     const mobo = prod({ m2_slots: 0, sata_6gbs: 4 })
     state.queue = [{ data: [{ product_id: 'sata-ssd' }, { product_id: 'hdd' }], error: null }]
 
     const res = await getCompatibleProductIds('storage', { motherboard: mobo })
 
     expect(res.filtered).toBe(true)
-    expect(state.callLog[0].ops).toContain('eq(nvme=false)')
+    expect(state.callLog[0].ops).toContain('or(nvme.eq.false,nvme.is.null)')
   })
 })

--- a/src/utils/__tests__/compatibility.test.ts
+++ b/src/utils/__tests__/compatibility.test.ts
@@ -78,14 +78,30 @@ describe('getCompatibleProductIds', () => {
       expect(result.filtered).toBe(false)
     })
 
-    it('queries pc_case_specs by form_factor containment', async () => {
-      mockResolvedData = [{ product_id: 'case-1' }]
+    it('filters pc_case_specs by normalized form_factor (tolerant matching)', async () => {
+      mockResolvedData = [
+        { product_id: 'case-1', supported_mobo_form_factors: ['ATX', 'Micro ATX'] },
+        { product_id: 'case-2', supported_mobo_form_factors: ['Mini ITX'] },
+        { product_id: 'case-3', supported_mobo_form_factors: null }, // donnée manquante → passe
+      ]
       const result = await getCompatibleProductIds('pc_case', {
         motherboard: makeProduct({ form_factor: 'ATX' }),
       })
       expect(result.filtered).toBe(true)
-      expect(result.productIds).toEqual(['case-1'])
-      expect(mockBuilder.contains).toHaveBeenCalledWith('supported_mobo_form_factors', ['ATX'])
+      expect(result.productIds).toEqual(['case-1', 'case-3'])
+      expect(result.reason).toContain('ATX')
+    })
+
+    it('matches Micro ATX vs mATX vs Micro-ATX via normalization', async () => {
+      mockResolvedData = [
+        { product_id: 'case-1', supported_mobo_form_factors: ['mATX'] },
+        { product_id: 'case-2', supported_mobo_form_factors: ['Micro ATX'] },
+        { product_id: 'case-3', supported_mobo_form_factors: ['Micro-ATX'] },
+      ]
+      const result = await getCompatibleProductIds('pc_case', {
+        motherboard: makeProduct({ form_factor: 'Micro ATX' }),
+      })
+      expect(result.productIds).toEqual(['case-1', 'case-2', 'case-3'])
     })
   })
 
@@ -131,30 +147,45 @@ describe('getCompatibleProductIds', () => {
       expect(result.filtered).toBe(false)
     })
 
-    it('returns filtered:false when motherboard has both M.2 and SATA', async () => {
+    it('returns filtered:false when motherboard has both M.2 and SATA (numbers)', async () => {
       const result = await getCompatibleProductIds('storage', {
         motherboard: makeProduct({ m2_slots: 2, sata_6gbs: 4 }),
       })
       expect(result.filtered).toBe(false)
     })
 
-    it('excludes NVMe when motherboard has no M.2 slot', async () => {
+    it('returns filtered:false when m2_slots est un objet JSONB non-vide (BuildCores) — info présente', async () => {
+      // Cas réel : m2_slots = { count: 2, types: [...] } stocké en JSONB.
+      const result = await getCompatibleProductIds('storage', {
+        motherboard: makeProduct({ m2_slots: { count: 2, types: ['PCIe 4.0'] }, sata_6gbs: 4 }),
+      })
+      expect(result.filtered).toBe(false)
+    })
+
+    it('returns filtered:false when slots info is unknown (does not over-filter)', async () => {
+      const result = await getCompatibleProductIds('storage', {
+        motherboard: makeProduct({ m2_slots: null, sata_6gbs: 4 }),
+      })
+      expect(result.filtered).toBe(false)
+    })
+
+    it('excludes NVMe when m2 absent and SATA present (mais accepte nvme=null)', async () => {
       mockResolvedData = [{ product_id: 'sata-1' }]
       const result = await getCompatibleProductIds('storage', {
         motherboard: makeProduct({ m2_slots: 0, sata_6gbs: 4 }),
       })
       expect(result.filtered).toBe(true)
-      expect(mockBuilder.eq).toHaveBeenCalledWith('nvme', false)
+      expect(mockBuilder.or).toHaveBeenCalledWith('nvme.eq.false,nvme.is.null')
       expect(result.reason).toContain('SATA')
     })
 
-    it('excludes SATA when motherboard has no SATA ports', async () => {
+    it('excludes SATA when sata absent and M.2 present (mais accepte nvme=null)', async () => {
       mockResolvedData = [{ product_id: 'nvme-1' }]
       const result = await getCompatibleProductIds('storage', {
         motherboard: makeProduct({ m2_slots: 2, sata_6gbs: 0 }),
       })
       expect(result.filtered).toBe(true)
-      expect(mockBuilder.eq).toHaveBeenCalledWith('nvme', true)
+      expect(mockBuilder.or).toHaveBeenCalledWith('nvme.eq.true,nvme.is.null')
       expect(result.reason).toContain('NVMe')
     })
   })

--- a/src/utils/__tests__/compatibility.test.ts
+++ b/src/utils/__tests__/compatibility.test.ts
@@ -3,7 +3,13 @@ import { getCompatibleProductIds } from '../compatibility'
 import type { Product } from '../../types'
 
 // Chainable mock that resolves with configurable data
-let mockResolvedData: { product_id: string; form_factor?: string; height_mm?: number; length_mm?: number }[] = []
+let mockResolvedData: Array<{
+  product_id: string
+  form_factor?: string
+  height_mm?: number
+  length_mm?: number
+  supported_mobo_form_factors?: string[] | null
+}> = []
 
 const mockBuilder = {
   select: vi.fn().mockReturnThis(),

--- a/src/utils/compatibility.ts
+++ b/src/utils/compatibility.ts
@@ -8,6 +8,71 @@ export interface CompatibilityResult {
 }
 
 /**
+ * Normalise une chaîne de format de carte mère pour comparaison tolérante.
+ * Ex : "Mini-ITX", "Mini ITX", "MiniITX", "mini itx" → "miniitx"
+ *      "Micro ATX", "mATX", "Micro-ATX", "uATX" → "matx" / "microatx"
+ *      "E-ATX", "Extended ATX" → "eatx" / "extendedatx"
+ * On ne corrige pas tout : on retire espaces, tirets, et on lowercase. Si la
+ * base contient encore des disparités, le filtre laisse passer (cf. cas par
+ * défaut dans pc_case ci-dessous).
+ */
+function normalizeFormFactor(v: string): string {
+  let s = v.toLowerCase().replace(/[\s\-_.]+/g, '')
+  // Alias courants : mATX/uATX → matx ; eATX/EATX → eatx
+  s = s.replace(/^(micro|u|µ)atx$/, 'matx')
+  s = s.replace(/^extendedatx$/, 'eatx')
+  s = s.replace(/^miniitx$/, 'mitx')
+  return s
+}
+
+/**
+ * Détecte si une spec de slot (m2_slots / sata_6gbs) indique présence, absence,
+ * ou information inconnue. m2_slots est souvent un objet JSONB de BuildCores
+ * ({ count: N } ou { types: [...] }), parfois un nombre, parfois null.
+ * sata_6gbs est généralement un nombre mais peut être null.
+ *
+ * Règle : on retourne 'unknown' quand l'info manque ou est dans un format non
+ * reconnu — l'appelant peut alors décider de ne pas filtrer plutôt que de
+ * filtrer à tort.
+ */
+function detectSlotPresence(raw: unknown): 'present' | 'absent' | 'unknown' {
+  if (raw === null || raw === undefined) return 'unknown'
+
+  // Nombre brut (sata_6gbs typique).
+  if (typeof raw === 'number') {
+    if (Number.isNaN(raw)) return 'unknown'
+    return raw > 0 ? 'present' : 'absent'
+  }
+
+  // String numérique éventuelle.
+  if (typeof raw === 'string') {
+    const n = Number(raw)
+    if (!Number.isNaN(n)) return n > 0 ? 'present' : 'absent'
+    return 'unknown'
+  }
+
+  // Array (liste de slots).
+  if (Array.isArray(raw)) {
+    return raw.length > 0 ? 'present' : 'absent'
+  }
+
+  // Objet JSONB BuildCores : { count: 2, types: [...] } ou { "M.2 PCIe 4.0": 2 } etc.
+  if (typeof raw === 'object') {
+    const obj = raw as Record<string, unknown>
+    if (typeof obj['count'] === 'number') return obj['count'] > 0 ? 'present' : 'absent'
+    if (Array.isArray(obj['types'])) return obj['types'].length > 0 ? 'present' : 'absent'
+    // Heuristique : si l'objet a au moins une clé avec une valeur > 0 (count par type), on considère présent.
+    const values = Object.values(obj)
+    const anyPositive = values.some((v) => typeof v === 'number' && v > 0)
+    if (anyPositive) return 'present'
+    // Sinon données ambiguës.
+    return Object.keys(obj).length > 0 ? 'present' : 'absent'
+  }
+
+  return 'unknown'
+}
+
+/**
  * Returns compatible product IDs for a target category based on already selected components.
  * Returns { filtered: false } if no relevant component is selected yet.
  *
@@ -44,18 +109,34 @@ export async function getCompatibleProductIds(
       }
     }
 
+    // Boîtier : filtre par format mobo, mais tolérant aux variations de nommage
+    // ("ATX" vs "Standard-ATX", "Micro ATX" vs "mATX" vs "Micro-ATX", etc.)
+    // Plutôt que d'utiliser contains() côté Postgres (exact match strict), on
+    // récupère toutes les specs et on filtre en JS avec normalisation.
     case 'pc_case': {
       const formFactor = motherboard?.specs?.['form_factor'] as string | undefined
       if (!formFactor) return { filtered: false, productIds: [] }
 
       const { data } = await supabase
         .from('pc_case_specs')
-        .select('product_id')
-        .contains('supported_mobo_form_factors', [formFactor])
+        .select('product_id, supported_mobo_form_factors')
+
+      if (!data) return { filtered: true, productIds: [], reason: `Format ${formFactor}` }
+
+      const target = normalizeFormFactor(formFactor)
+      const matching = data.filter((row) => {
+        const supported = (row as Record<string, unknown>)['supported_mobo_form_factors'] as
+          | string[]
+          | null
+          | undefined
+        // Si la spec n'a pas de liste → on laisse passer (donnée incomplète, plutôt que d'exclure à tort).
+        if (!supported || !Array.isArray(supported) || supported.length === 0) return true
+        return supported.some((s) => normalizeFormFactor(s) === target)
+      })
 
       return {
         filtered: true,
-        productIds: data?.map((r) => r.product_id) ?? [],
+        productIds: matching.map((r) => r.product_id),
         reason: `Format ${formFactor}`,
       }
     }
@@ -94,23 +175,39 @@ export async function getCompatibleProductIds(
       }
     }
 
+    // Stockage : interpréter m2_slots et sata_6gbs prudemment.
+    // m2_slots est stocké en JSONB par l'import BuildCores (objet { count, types[] })
+    // — un cast brutal en number donne NaN et fausse tout. sata_6gbs est un nombre
+    // mais peut être null si l'info est manquante. Principe : on n'exclut une
+    // famille (NVMe ou SATA) que si on est CERTAIN qu'elle est incompatible.
     case 'storage': {
       if (!motherboard) return { filtered: false, productIds: [] }
 
-      const m2Slots   = motherboard.specs?.['m2_slots']  as number | undefined
-      const sataPorts = motherboard.specs?.['sata_6gbs'] as number | undefined
+      const m2Raw   = motherboard.specs?.['m2_slots']
+      const sataRaw = motherboard.specs?.['sata_6gbs']
 
-      const hasM2   = (m2Slots ?? 0) > 0
-      const hasSata = (sataPorts ?? 0) > 0
+      const m2Status   = detectSlotPresence(m2Raw)
+      const sataStatus = detectSlotPresence(sataRaw)
 
-      if (!hasM2 && !hasSata) return { filtered: false, productIds: [] }
-      if (hasM2 && hasSata)   return { filtered: false, productIds: [] } // tout compatible
+      // Si on ne sait pas (donnée manquante ou format inconnu) → on ne filtre pas.
+      if (m2Status === 'unknown' || sataStatus === 'unknown') {
+        return { filtered: false, productIds: [] }
+      }
+      // Les deux présents → tout compatible.
+      if (m2Status === 'present' && sataStatus === 'present') {
+        return { filtered: false, productIds: [] }
+      }
+      // Aucun des deux → mobo bizarre, on laisse passer pour ne pas bloquer.
+      if (m2Status === 'absent' && sataStatus === 'absent') {
+        return { filtered: false, productIds: [] }
+      }
 
-      if (!hasM2 && hasSata) {
+      // Pas de M.2 → SATA uniquement (exclure NVMe).
+      if (m2Status === 'absent' && sataStatus === 'present') {
         const { data } = await supabase
           .from('storage_specs')
           .select('product_id')
-          .eq('nvme', false)
+          .or('nvme.eq.false,nvme.is.null')
 
         return {
           filtered: true,
@@ -119,10 +216,11 @@ export async function getCompatibleProductIds(
         }
       }
 
+      // Pas de SATA → M.2 NVMe uniquement.
       const { data } = await supabase
         .from('storage_specs')
         .select('product_id')
-        .eq('nvme', true)
+        .or('nvme.eq.true,nvme.is.null')
 
       return {
         filtered: true,

--- a/src/utils/selection-order.ts
+++ b/src/utils/selection-order.ts
@@ -1,5 +1,34 @@
 import type { CategoryKey, Product } from '../types'
 
+// Helpers locaux : mêmes règles que compatibility.ts, dupliquées ici pour
+// éviter un import circulaire (selection-order est consommé par le store).
+function normalizeFormFactorLocal(v: string): string {
+  let s = v.toLowerCase().replace(/[\s\-_.]+/g, '')
+  s = s.replace(/^(micro|u|µ)atx$/, 'matx')
+  s = s.replace(/^extendedatx$/, 'eatx')
+  s = s.replace(/^miniitx$/, 'mitx')
+  return s
+}
+
+function detectSlotPresenceLocal(raw: unknown): 'present' | 'absent' | 'unknown' {
+  if (raw === null || raw === undefined) return 'unknown'
+  if (typeof raw === 'number') return Number.isNaN(raw) ? 'unknown' : (raw > 0 ? 'present' : 'absent')
+  if (typeof raw === 'string') {
+    const n = Number(raw)
+    return Number.isNaN(n) ? 'unknown' : (n > 0 ? 'present' : 'absent')
+  }
+  if (Array.isArray(raw)) return raw.length > 0 ? 'present' : 'absent'
+  if (typeof raw === 'object') {
+    const obj = raw as Record<string, unknown>
+    if (typeof obj['count'] === 'number') return obj['count'] > 0 ? 'present' : 'absent'
+    if (Array.isArray(obj['types'])) return obj['types'].length > 0 ? 'present' : 'absent'
+    const anyPositive = Object.values(obj).some((v) => typeof v === 'number' && v > 0)
+    if (anyPositive) return 'present'
+    return Object.keys(obj).length > 0 ? 'present' : 'absent'
+  }
+  return 'unknown'
+}
+
 /**
  * Ordre recommandé de sélection des composants.
  * Suit la logique d'un montage PC : on part du CPU (qui définit le socket),
@@ -79,17 +108,22 @@ function specIsCompatible(
     case 'pc_case': {
       const mobof = motherboard?.specs?.['form_factor'] as string | undefined
       const supported = specs['supported_mobo_form_factors'] as string[] | undefined
-      if (mobof && supported && !supported.includes(mobof)) return false
-      return true
+      // Si la spec boîtier n'a pas de liste ou que la mobo n'a pas de format renseigné,
+      // on laisse passer (ne pas exclure à tort).
+      if (!mobof || !supported || !Array.isArray(supported) || supported.length === 0) return true
+      const target = normalizeFormFactorLocal(mobof)
+      return supported.some((s) => normalizeFormFactorLocal(s) === target)
     }
     case 'storage': {
-      const m2Slots = motherboard?.specs?.['m2_slots'] as number | undefined
-      const sataPorts = motherboard?.specs?.['sata_6gbs'] as number | undefined
+      const m2Status = detectSlotPresenceLocal(motherboard?.specs?.['m2_slots'])
+      const sataStatus = detectSlotPresenceLocal(motherboard?.specs?.['sata_6gbs'])
       const isNvme = specs['nvme'] as boolean | undefined
-      if (m2Slots !== undefined && sataPorts !== undefined && isNvme !== undefined) {
-        if (isNvme && m2Slots === 0) return false
-        if (!isNvme && sataPorts === 0) return false
-      }
+      // Si une info manque → on laisse passer.
+      if (m2Status === 'unknown' || sataStatus === 'unknown' || isNvme === undefined) return true
+      // NVMe mais pas de slot M.2 → KO.
+      if (isNvme && m2Status === 'absent') return false
+      // SATA mais pas de port SATA → KO.
+      if (!isNvme && sataStatus === 'absent') return false
       return true
     }
     case 'cpu_cooler': {


### PR DESCRIPTION
## Symptôme

Dans la quasi-totalité des cas, sélectionner une carte mère faisait disparaître **toute la liste des boîtiers** OU **tous les SSD M.2 NVMe**, alors que le catalogue contient des centaines de produits compatibles.

## Causes identifiées

### Bug 1 — Storage : m2_slots est en JSONB, pas en nombre

L'import BuildCores stocke \`m2_slots\` en JSONB (\`{ count: N, types: [...] }\`). Le code \`compatibility.ts\` faisait \`(m2Slots ?? 0) > 0\` en castant en \`number\` :

\`\`\`js
const m2Slots = motherboard.specs?.['m2_slots'] as number | undefined
const hasM2 = (m2Slots ?? 0) > 0  // ← (objet > 0) = (NaN > 0) = false TOUJOURS
\`\`\`

Conséquence : \`hasM2\` était systématiquement \`false\`, on tombait dans la branche \"pas de M.2 → exclure NVMe\", et **aucun SSD NVMe n'apparaissait jamais**. Inversement, sur une mobo sans SATA, tous les SATA étaient exclus.

### Bug 2 — pc_case : matching exact des form factors

\`\`\`js
.contains('supported_mobo_form_factors', [formFactor])
\`\`\`

Cette requête Postgres exige un match **exactement identique** à la chaîne. Si la mobo stocke \`\"Micro ATX\"\` mais que certains boîtiers stockent \`\"Micro-ATX\"\`, \`\"mATX\"\`, ou \`\"µATX\"\`, **aucun match**. La base BuildCores contient ce genre de variations selon les sources.

## Fix

### Helper \`detectSlotPresence(raw)\`

Interprète intelligemment selon le type :

| Input | Output |
|---|---|
| \`null\` / \`undefined\` | \`'unknown'\` |
| \`number\` | \`'present'\` si > 0, sinon \`'absent'\` |
| \`string\` numérique | idem nombre |
| \`array\` | \`'present'\` si non vide |
| \`object\` JSONB \`{ count: N }\` | basé sur \`count\` |
| \`object\` JSONB \`{ types: [...] }\` | basé sur \`types.length\` |
| objet avec valeurs numériques | présent si au moins une > 0 |

**Règle d'or** : si \`'unknown'\` → on ne filtre pas. Mieux vaut un peu trop de composants que zéro.

### Helper \`normalizeFormFactor(v)\`

Normalise pour comparaison tolérante :

- Retire espaces, tirets, underscores, points
- Lowercase
- Réduit les alias : \`Micro ATX = mATX = µATX = Micro-ATX → matx\`
- Idem pour \`Mini ITX = Mini-ITX = MiniITX → mitx\`
- Idem pour \`Extended ATX = E-ATX → eatx\`

### Nouveau filtre boîtier

Plutôt qu'un \`contains()\` Postgres strict, on récupère toutes les specs et on filtre côté JS avec \`normalizeFormFactor\`. Si une spec n'a pas de liste \`supported_mobo_form_factors\` (donnée manquante) → on **laisse passer** plutôt que d'exclure à tort.

### Nouveau filtre stockage

Au lieu de \`.eq('nvme', false)\`, on fait \`.or('nvme.eq.false,nvme.is.null')\` pour accepter aussi les produits dont le champ \`nvme\` n'est pas renseigné en base.

### Cascade d'invalidation

Les mêmes helpers sont dupliqués dans \`selection-order.ts\` (évite un import circulaire avec le store) pour que la cascade utilise la même logique tolérante.

## Tests

- **70 verts** (+5 nouveaux) : normalization, JSONB m2_slots, cas unknown.
- Tests ajustés : \`contains()\` → JS filter, \`eq(nvme, X)\` → \`or(nvme.eq.X, nvme.is.null)\`.

## Test plan

- [ ] Sélectionner une carte mère ATX → la liste des boîtiers contient des cases ATX/mATX/E-ATX (ceux qui supportent ATX).
- [ ] Sélectionner une carte mère Micro ATX → les cases supportant \`mATX\` ou \`Micro-ATX\` (notation différente) apparaissent aussi.
- [ ] Sélectionner une carte mère avec \`m2_slots\` en JSONB (cas BuildCores standard) → tout le catalogue stockage reste affiché.
- [ ] Sélectionner une carte mère avec \`m2_slots: 0\` strictement → les NVMe sont exclus, les SATA + storage sans flag nvme passent.
- [ ] Sélectionner une carte mère avec \`sata_6gbs: 0\` strictement → les SATA sont exclus, les NVMe + storage sans flag nvme passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)