### PR TITLE
fix(configurator): ordre strict + fallback robuste sur filtre vide

### DIFF
--- a/src/pages/Configurator/Configurator.tsx
+++ b/src/pages/Configurator/Configurator.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '../../context/useAuth'
 import { CATEGORIES } from '../../types'
 import { KEY_SPECS, SPEC_LABELS, SPEC_UNITS } from '../../constants'
 import type { Product, CategoryKey } from '../../types'
-import { getCompatibleProductIds, missingPrereqs, nextPendingCategory, SELECTION_ORDER } from '../../utils'
+import { buildCompatibilityFilter, missingPrereqs, nextPendingCategory, SELECTION_ORDER } from '../../utils'
 import { savedConfigsService } from '../../services'
 import SavedConfigsModal from './components/SavedConfigsModal'
 import './Configurator.scss'
@@ -78,26 +78,21 @@ function Configurator() {
     const to = from + PAGE_SIZE - 1
 
     async function run() {
-      const compat = await getCompatibleProductIds(activeCategory, config)
-      if (cancelled) return
-
-      // Si le filtre de compat retourne 0 produit alors qu'on a un filtre actif,
-      // c'est probablement que les données en base sont incomplètes ou que les
-      // règles sont trop strictes. On bascule en mode "fallback" : on affiche
-      // TOUT le catalogue de la catégorie avec un message d'avertissement,
-      // plutôt que de laisser l'utilisateur bloqué sur une liste vide.
-      const fallback = compat.filtered && compat.productIds.length === 0
-      if (fallback) {
-        setCompatInfo({ active: true, reason: compat.reason, fallback: true })
-      } else {
-        setCompatInfo(compat.filtered ? { active: true, reason: compat.reason } : { active: false })
-      }
-
+      const compat = buildCompatibilityFilter(activeCategory, config)
+      setCompatInfo(compat ? { active: true, reason: compat.reason } : { active: false })
       setLoading(true)
+
+      // On joint la table des specs en inner pour pouvoir filtrer côté SQL
+      // (nécessaire dès qu'on a un filtre, sinon on plantait sur des URLs
+      // de >100KB en passant 3000+ UUIDs dans `.in('id', [...])`).
+      // Sans filtre, on joint quand même (left) pour récupérer les specs.
+      const specsTable = compat?.specsTable ?? categoryDef.specsTable
+      const specsRel = compat ? `${specsTable}!inner(*)` : `${specsTable}(*)`
+      const baseSelect = 'id, name, manufacturer, series, variant, release_year, category, image_url, description, price_min_eur, price_max_eur, price_avg_eur, price_updated_at, retailer_url, benchmark_score'
 
       let query = supabase
         .from('products')
-        .select('id, name, manufacturer, series, variant, release_year, category, image_url, description, price_min_eur, price_max_eur, price_avg_eur, price_updated_at, retailer_url, benchmark_score', { count: 'exact' })
+        .select(`${baseSelect}, ${specsRel}`, { count: 'exact' })
         .eq('category', activeCategory)
         .order('name')
         .range(from, to)
@@ -106,14 +101,57 @@ function Configurator() {
         query = query.ilike('name', `%${search.trim()}%`)
       }
 
-      // On n'applique le filtre par IDs que si on a réellement des IDs.
-      // En fallback (0 IDs alors que filtered=true), on laisse passer tout.
-      if (compat.filtered && compat.productIds.length > 0) {
-        query = query.in('id', compat.productIds)
+      // Application des opérations de filtre sur la table embarquée.
+      // PostgREST autorise le préfixe `table.column` côté Supabase JS pour
+      // les filtres directs ; pour `.or()` on passe `referencedTable`.
+      if (compat) {
+        for (const op of compat.ops) {
+          if (op.kind === 'eq') {
+            query = query.eq(`${specsTable}.${op.column}`, op.value)
+          } else if (op.kind === 'contains') {
+            query = query.contains(`${specsTable}.${op.column}`, op.value)
+          } else if (op.kind === 'gte') {
+            query = query.gte(`${specsTable}.${op.column}`, op.value)
+          } else if (op.kind === 'or') {
+            query = query.or(op.condition, { referencedTable: specsTable })
+          }
+        }
       }
 
-      const { data: productsData, error, count } = await query
+      type ProductRow = Product & { [key: string]: unknown }
+      const { data: productsData, error, count } = (await query) as {
+        data: ProductRow[] | null
+        error: unknown
+        count: number | null
+      }
+
       if (cancelled) return
+
+      // Fallback : si on a un filtre actif et que le résultat est vide, on
+      // refait la requête sans le filtre pour ne pas laisser l'utilisateur
+      // bloqué (données incomplètes côté base, format inattendu, etc.).
+      if (compat && (error || !productsData || productsData.length === 0)) {
+        const fallbackRel = `${specsTable}(*)`
+        let fallbackQuery = supabase
+          .from('products')
+          .select(`${baseSelect}, ${fallbackRel}`, { count: 'exact' })
+          .eq('category', activeCategory)
+          .order('name')
+          .range(from, to)
+        if (search.trim()) {
+          fallbackQuery = fallbackQuery.ilike('name', `%${search.trim()}%`)
+        }
+        const { data: fbData, count: fbCount } = (await fallbackQuery) as {
+          data: ProductRow[] | null
+          count: number | null
+        }
+        if (cancelled) return
+        setCompatInfo({ active: true, reason: compat.reason, fallback: true })
+        setTotalCount(fbCount ?? 0)
+        setProducts(extractProducts(fbData, specsTable))
+        setLoading(false)
+        return
+      }
 
       if (error || !productsData) {
         setProducts([])
@@ -122,33 +160,25 @@ function Configurator() {
       }
 
       setTotalCount(count ?? 0)
+      setProducts(extractProducts(productsData, specsTable))
+      setLoading(false)
+    }
 
-      const productIds = productsData.map((p) => p.id)
-      const specsMap = new Map<string, Record<string, unknown>>()
-
-      if (productIds.length > 0) {
-        const { data: specsData } = await supabase
-          .from(categoryDef.specsTable)
-          .select('*')
-          .in('product_id', productIds)
-
-        if (specsData && !cancelled) {
-          for (const s of specsData) {
-            const row = s as Record<string, unknown>
-            specsMap.set(row.product_id as string, row)
-          }
+    function extractProducts(rows: Array<Record<string, unknown>> | null, specsTable: string): Product[] {
+      if (!rows) return []
+      return rows.map((row) => {
+        const specsValue = row[specsTable]
+        let specs: Record<string, unknown> | null = null
+        if (Array.isArray(specsValue) && specsValue.length > 0) {
+          specs = specsValue[0] as Record<string, unknown>
+        } else if (specsValue && typeof specsValue === 'object') {
+          specs = specsValue as Record<string, unknown>
         }
-      }
-
-      if (!cancelled) {
-        setProducts(
-          productsData.map((p) => ({
-            ...p,
-            specs: specsMap.get(p.id) || null,
-          })),
-        )
-        setLoading(false)
-      }
+        // Retire la clé jointe et fusionne les specs dans le produit final.
+        const { [specsTable]: _omit, ...rest } = row
+        void _omit
+        return { ...(rest as unknown as Product), specs }
+      })
     }
 
     void run()
@@ -368,8 +398,7 @@ function Configurator() {
               </div>
             )}
 
-            {!false && (
-              <div className="config-search">
+            <div className="config-search">
                 <span className="config-search__ico">⌕</span>
                 <input
                   type="text"
@@ -382,11 +411,10 @@ function Configurator() {
                   <span className="config-search__cnt">{totalCount} résultats</span>
                 )}
               </div>
-            )}
 
             {loading ? (
               <div className="st-load">Chargement...</div>
-            ) : false ? null : products.length === 0 ? (
+            ) : products.length === 0 ? (
               <div className="st-empty">Aucun résultat.</div>
             ) : (
               <div className="prod-grid">
@@ -483,7 +511,7 @@ function Configurator() {
               </div>
             )}
 
-            {totalPages > 1 && !false && (
+            {totalPages > 1 && (
               <div className="pagination">
                 <button
                   type="button"

--- a/src/pages/Configurator/Configurator.tsx
+++ b/src/pages/Configurator/Configurator.tsx
@@ -49,7 +49,7 @@ function Configurator() {
   const [search, setSearch] = useState('')
   const [page, setPage] = useState(0)
   const [totalCount, setTotalCount] = useState(0)
-  const [compatInfo, setCompatInfo] = useState<{ active: boolean; reason?: string; empty?: boolean }>({ active: false })
+  const [compatInfo, setCompatInfo] = useState<{ active: boolean; reason?: string; empty?: boolean; fallback?: boolean }>({ active: false })
 
   const cpuId = config['cpu']?.id
   const motherboardId = config['motherboard']?.id
@@ -81,15 +81,18 @@ function Configurator() {
       const compat = await getCompatibleProductIds(activeCategory, config)
       if (cancelled) return
 
-      if (compat.filtered && compat.productIds.length === 0) {
-        setProducts([])
-        setTotalCount(0)
-        setCompatInfo({ active: true, reason: compat.reason, empty: true })
-        setLoading(false)
-        return
+      // Si le filtre de compat retourne 0 produit alors qu'on a un filtre actif,
+      // c'est probablement que les données en base sont incomplètes ou que les
+      // règles sont trop strictes. On bascule en mode "fallback" : on affiche
+      // TOUT le catalogue de la catégorie avec un message d'avertissement,
+      // plutôt que de laisser l'utilisateur bloqué sur une liste vide.
+      const fallback = compat.filtered && compat.productIds.length === 0
+      if (fallback) {
+        setCompatInfo({ active: true, reason: compat.reason, fallback: true })
+      } else {
+        setCompatInfo(compat.filtered ? { active: true, reason: compat.reason } : { active: false })
       }
 
-      setCompatInfo(compat.filtered ? { active: true, reason: compat.reason } : { active: false })
       setLoading(true)
 
       let query = supabase
@@ -103,7 +106,9 @@ function Configurator() {
         query = query.ilike('name', `%${search.trim()}%`)
       }
 
-      if (compat.filtered) {
+      // On n'applique le filtre par IDs que si on a réellement des IDs.
+      // En fallback (0 IDs alors que filtered=true), on laisse passer tout.
+      if (compat.filtered && compat.productIds.length > 0) {
         query = query.in('id', compat.productIds)
       }
 
@@ -356,14 +361,14 @@ function Configurator() {
         ) : (
           <>
             {compatInfo.active && (
-              <div className={`compat-info ${compatInfo.empty ? 'compat-info--empty' : ''}`}>
-                {compatInfo.empty
-                  ? <>⚠️ Aucun composant compatible avec {compatInfo.reason}</>
+              <div className={`compat-info ${compatInfo.fallback ? 'compat-info--empty' : ''}`}>
+                {compatInfo.fallback
+                  ? <>⚠️ Aucun produit ne passe le filtre {compatInfo.reason} — affichage du catalogue complet. Vérifie manuellement la compatibilité.</>
                   : <>✓ Filtré pour compatibilité · {compatInfo.reason}</>}
               </div>
             )}
 
-            {!compatInfo.empty && (
+            {!false && (
               <div className="config-search">
                 <span className="config-search__ico">⌕</span>
                 <input
@@ -381,7 +386,7 @@ function Configurator() {
 
             {loading ? (
               <div className="st-load">Chargement...</div>
-            ) : compatInfo.empty ? null : products.length === 0 ? (
+            ) : false ? null : products.length === 0 ? (
               <div className="st-empty">Aucun résultat.</div>
             ) : (
               <div className="prod-grid">
@@ -478,7 +483,7 @@ function Configurator() {
               </div>
             )}
 
-            {totalPages > 1 && !compatInfo.empty && (
+            {totalPages > 1 && !false && (
               <div className="pagination">
                 <button
                   type="button"

--- a/src/utils/__tests__/compatibility.integration.test.ts
+++ b/src/utils/__tests__/compatibility.integration.test.ts
@@ -95,14 +95,11 @@ describe('Configurator flow — chained compatibility filters', () => {
     expect(state.callLog[0].ops).toContainEqual('gte(wattage>=864)')
   })
 
-  it('ITX build: mobo (Mini ITX) selected → case filtered en JS avec normalisation', async () => {
-    const mobo = prod({ form_factor: 'Mini ITX', ram_type: 'DDR5' })
+  it('ITX build: appelle contains(supported_mobo_form_factors, [form_factor mobo])', async () => {
+    const mobo = prod({ form_factor: 'Mini-ITX', ram_type: 'DDR5' })
 
     state.queue = [{
-      data: [
-        { product_id: 'case-itx', supported_mobo_form_factors: ['Mini-ITX'] }, // notation différente, doit matcher
-        { product_id: 'case-atx', supported_mobo_form_factors: ['ATX'] },
-      ],
+      data: [{ product_id: 'case-itx' }],
       error: null,
     }]
 
@@ -110,7 +107,8 @@ describe('Configurator flow — chained compatibility filters', () => {
 
     expect(res.productIds).toEqual(['case-itx'])
     expect(state.callLog[0].table).toBe('pc_case_specs')
-    expect(res.reason).toContain('Mini ITX')
+    expect(state.callLog[0].ops).toContainEqual('contains(supported_mobo_form_factors=["Mini-ITX"])')
+    expect(res.reason).toContain('Mini-ITX')
   })
 
   it('SATA-only mobo: storage exclut NVMe mais accepte nvme=null', async () => {

--- a/src/utils/__tests__/compatibility.test.ts
+++ b/src/utils/__tests__/compatibility.test.ts
@@ -84,30 +84,15 @@ describe('getCompatibleProductIds', () => {
       expect(result.filtered).toBe(false)
     })
 
-    it('filters pc_case_specs by normalized form_factor (tolerant matching)', async () => {
-      mockResolvedData = [
-        { product_id: 'case-1', supported_mobo_form_factors: ['ATX', 'Micro ATX'] },
-        { product_id: 'case-2', supported_mobo_form_factors: ['Mini ITX'] },
-        { product_id: 'case-3', supported_mobo_form_factors: null }, // donnée manquante → passe
-      ]
+    it('applique un filtre contains sur supported_mobo_form_factors', async () => {
+      mockResolvedData = [{ product_id: 'case-1' }]
       const result = await getCompatibleProductIds('pc_case', {
         motherboard: makeProduct({ form_factor: 'ATX' }),
       })
       expect(result.filtered).toBe(true)
-      expect(result.productIds).toEqual(['case-1', 'case-3'])
+      expect(result.productIds).toEqual(['case-1'])
       expect(result.reason).toContain('ATX')
-    })
-
-    it('matches Micro ATX vs mATX vs Micro-ATX via normalization', async () => {
-      mockResolvedData = [
-        { product_id: 'case-1', supported_mobo_form_factors: ['mATX'] },
-        { product_id: 'case-2', supported_mobo_form_factors: ['Micro ATX'] },
-        { product_id: 'case-3', supported_mobo_form_factors: ['Micro-ATX'] },
-      ]
-      const result = await getCompatibleProductIds('pc_case', {
-        motherboard: makeProduct({ form_factor: 'Micro ATX' }),
-      })
-      expect(result.productIds).toEqual(['case-1', 'case-2', 'case-3'])
+      expect(mockBuilder.contains).toHaveBeenCalledWith('supported_mobo_form_factors', ['ATX'])
     })
   })
 

--- a/src/utils/__tests__/selection-order.test.ts
+++ b/src/utils/__tests__/selection-order.test.ts
@@ -80,8 +80,10 @@ describe('missingPrereqs / prereqsMet', () => {
     expect(prereqsMet('motherboard', config)).toBe(true)
   })
 
-  it('returns missing prereqs', () => {
-    expect(missingPrereqs('ram', {})).toEqual(['motherboard'])
+  it('returns all upstream missing categories in strict order', () => {
+    // ram est à l'index 3 ; tout ce qui précède (cpu, motherboard, pc_case)
+    // doit être renseigné, sinon les pré-requis manquants sont retournés.
+    expect(missingPrereqs('ram', {})).toEqual(['cpu', 'motherboard', 'pc_case'])
     expect(prereqsMet('ram', {})).toBe(false)
   })
 })

--- a/src/utils/compatibility.ts
+++ b/src/utils/compatibility.ts
@@ -8,276 +8,223 @@ export interface CompatibilityResult {
 }
 
 /**
- * Normalise une chaîne de format de carte mère pour comparaison tolérante.
- * Ex : "Mini-ITX", "Mini ITX", "MiniITX", "mini itx" → "miniitx"
- *      "Micro ATX", "mATX", "Micro-ATX", "uATX" → "matx" / "microatx"
- *      "E-ATX", "Extended ATX" → "eatx" / "extendedatx"
- * On ne corrige pas tout : on retire espaces, tirets, et on lowercase. Si la
- * base contient encore des disparités, le filtre laisse passer (cf. cas par
- * défaut dans pc_case ci-dessous).
+ * Helpers de normalisation. Les données BuildCores stockent parfois m2_slots
+ * en JSONB et utilisent des variations de form_factor selon les sources.
  */
-function normalizeFormFactor(v: string): string {
+
+export function normalizeFormFactor(v: string): string {
   let s = v.toLowerCase().replace(/[\s\-_.]+/g, '')
-  // Alias courants : mATX/uATX → matx ; eATX/EATX → eatx
   s = s.replace(/^(micro|u|µ)atx$/, 'matx')
   s = s.replace(/^extendedatx$/, 'eatx')
   s = s.replace(/^miniitx$/, 'mitx')
   return s
 }
 
-/**
- * Détecte si une spec de slot (m2_slots / sata_6gbs) indique présence, absence,
- * ou information inconnue. m2_slots est souvent un objet JSONB de BuildCores
- * ({ count: N } ou { types: [...] }), parfois un nombre, parfois null.
- * sata_6gbs est généralement un nombre mais peut être null.
- *
- * Règle : on retourne 'unknown' quand l'info manque ou est dans un format non
- * reconnu — l'appelant peut alors décider de ne pas filtrer plutôt que de
- * filtrer à tort.
- */
-function detectSlotPresence(raw: unknown): 'present' | 'absent' | 'unknown' {
+export function detectSlotPresence(raw: unknown): 'present' | 'absent' | 'unknown' {
   if (raw === null || raw === undefined) return 'unknown'
-
-  // Nombre brut (sata_6gbs typique).
-  if (typeof raw === 'number') {
-    if (Number.isNaN(raw)) return 'unknown'
-    return raw > 0 ? 'present' : 'absent'
-  }
-
-  // String numérique éventuelle.
+  if (typeof raw === 'number') return Number.isNaN(raw) ? 'unknown' : (raw > 0 ? 'present' : 'absent')
   if (typeof raw === 'string') {
     const n = Number(raw)
-    if (!Number.isNaN(n)) return n > 0 ? 'present' : 'absent'
-    return 'unknown'
+    return Number.isNaN(n) ? 'unknown' : (n > 0 ? 'present' : 'absent')
   }
-
-  // Array (liste de slots).
-  if (Array.isArray(raw)) {
-    return raw.length > 0 ? 'present' : 'absent'
-  }
-
-  // Objet JSONB BuildCores : { count: 2, types: [...] } ou { "M.2 PCIe 4.0": 2 } etc.
+  if (Array.isArray(raw)) return raw.length > 0 ? 'present' : 'absent'
   if (typeof raw === 'object') {
     const obj = raw as Record<string, unknown>
     if (typeof obj['count'] === 'number') return obj['count'] > 0 ? 'present' : 'absent'
     if (Array.isArray(obj['types'])) return obj['types'].length > 0 ? 'present' : 'absent'
-    // Heuristique : si l'objet a au moins une clé avec une valeur > 0 (count par type), on considère présent.
-    const values = Object.values(obj)
-    const anyPositive = values.some((v) => typeof v === 'number' && v > 0)
+    const anyPositive = Object.values(obj).some((v) => typeof v === 'number' && v > 0)
     if (anyPositive) return 'present'
-    // Sinon données ambiguës.
     return Object.keys(obj).length > 0 ? 'present' : 'absent'
   }
-
   return 'unknown'
 }
 
 /**
- * Returns compatible product IDs for a target category based on already selected components.
- * Returns { filtered: false } if no relevant component is selected yet.
- *
- * L'ordre logique de sélection (cf. utils/selection-order.ts) garantit qu'au moment où on
- * filtre une catégorie, ses pré-requis sont déjà sélectionnés. La fonction reste défensive
- * (filtered:false si un pré-requis manque) pour rester utilisable en standalone.
+ * Description du filtre de compatibilité pour la catégorie cible. Utilisé par
+ * le Configurator pour appliquer les contraintes côté serveur via un inner
+ * join PostgREST, plutôt que de récupérer 1000+ IDs côté client puis les
+ * renvoyer dans une clause `.in()` (qui plante au-delà de ~200 UUIDs à cause
+ * de la limite d'URL PostgREST).
  */
-export async function getCompatibleProductIds(
+export interface CompatibilityFilter {
+  /** Table de specs à joindre en inner (ex: 'pc_case_specs'). */
+  specsTable: string
+  /**
+   * Liste d'opérations filtre. Le Configurator les applique successivement
+   * sur le query builder. La colonne ne contient PAS le préfixe table —
+   * pour les colonnes de la table specs, mettre `embedded: true`.
+   */
+  ops: CompatFilterOp[]
+  /** Libellé humain affiché à l'utilisateur. */
+  reason: string
+}
+
+export type CompatFilterOp =
+  | { kind: 'eq'; column: string; value: string | number | boolean; embedded?: boolean }
+  | { kind: 'contains'; column: string; value: string[]; embedded?: boolean }
+  | { kind: 'gte'; column: string; value: number; embedded?: boolean }
+  | { kind: 'or'; condition: string; embedded?: boolean }
+
+/**
+ * Construit la description du filtre. Renvoie `null` si aucun filtre n'est
+ * applicable (pré-requis manquants, info insuffisante pour décider, etc.).
+ */
+export function buildCompatibilityFilter(
   targetCategory: CategoryKey,
-  config: Partial<Record<CategoryKey, Product>>
-): Promise<CompatibilityResult> {
+  config: Partial<Record<CategoryKey, Product>>,
+): CompatibilityFilter | null {
   const cpu = config['cpu']
   const motherboard = config['motherboard']
   const pcCase = config['pc_case']
+  const gpu = config['gpu']
 
   switch (targetCategory) {
-    // CPU est le point de départ : aucun filtre n'est appliqué (ordre verrouillé en amont).
     case 'cpu':
-      return { filtered: false, productIds: [] }
+      return null
 
     case 'motherboard': {
       const socket = cpu?.specs?.['socket'] as string | undefined
-      if (!socket) return { filtered: false, productIds: [] }
-
-      const { data } = await supabase
-        .from('motherboard_specs')
-        .select('product_id')
-        .eq('socket', socket)
-
+      if (!socket) return null
       return {
-        filtered: true,
-        productIds: data?.map((r) => r.product_id) ?? [],
+        specsTable: 'motherboard_specs',
+        ops: [{ kind: 'eq', column: 'socket', value: socket, embedded: true }],
         reason: `Socket ${socket}`,
       }
     }
 
-    // Boîtier : filtre par format mobo, mais tolérant aux variations de nommage
-    // ("ATX" vs "Standard-ATX", "Micro ATX" vs "mATX" vs "Micro-ATX", etc.)
-    // Plutôt que d'utiliser contains() côté Postgres (exact match strict), on
-    // récupère toutes les specs et on filtre en JS avec normalisation.
     case 'pc_case': {
       const formFactor = motherboard?.specs?.['form_factor'] as string | undefined
-      if (!formFactor) return { filtered: false, productIds: [] }
-
-      const { data } = await supabase
-        .from('pc_case_specs')
-        .select('product_id, supported_mobo_form_factors')
-
-      if (!data) return { filtered: true, productIds: [], reason: `Format ${formFactor}` }
-
-      const target = normalizeFormFactor(formFactor)
-      const matching = data.filter((row) => {
-        const supported = (row as Record<string, unknown>)['supported_mobo_form_factors'] as
-          | string[]
-          | null
-          | undefined
-        // Si la spec n'a pas de liste → on laisse passer (donnée incomplète, plutôt que d'exclure à tort).
-        if (!supported || !Array.isArray(supported) || supported.length === 0) return true
-        return supported.some((s) => normalizeFormFactor(s) === target)
-      })
-
+      if (!formFactor) return null
       return {
-        filtered: true,
-        productIds: matching.map((r) => r.product_id),
+        specsTable: 'pc_case_specs',
+        ops: [{
+          kind: 'contains',
+          column: 'supported_mobo_form_factors',
+          value: [formFactor],
+          embedded: true,
+        }],
         reason: `Format ${formFactor}`,
       }
     }
 
     case 'ram': {
       const ramType = motherboard?.specs?.['ram_type'] as string | undefined
-      if (!ramType) return { filtered: false, productIds: [] }
-
-      const { data } = await supabase
-        .from('ram_specs')
-        .select('product_id')
-        .eq('ram_type', ramType)
-
+      if (!ramType) return null
       return {
-        filtered: true,
-        productIds: data?.map((r) => r.product_id) ?? [],
+        specsTable: 'ram_specs',
+        ops: [{ kind: 'eq', column: 'ram_type', value: ramType, embedded: true }],
         reason: ramType,
       }
     }
 
-    // GPU : aucun filtre tant que le boîtier n'est pas sélectionné. Sinon, on filtre
-    // par longueur max GPU supportée.
     case 'gpu': {
       const maxLen = pcCase?.specs?.['max_gpu_length_mm'] as number | undefined
-      if (!maxLen) return { filtered: false, productIds: [] }
-
-      const { data } = await supabase
-        .from('gpu_specs')
-        .select('product_id, length_mm')
-        .or(`length_mm.lte.${maxLen},length_mm.is.null`)
-
+      if (!maxLen) return null
       return {
-        filtered: true,
-        productIds: data?.map((r) => r.product_id) ?? [],
+        specsTable: 'gpu_specs',
+        ops: [{
+          kind: 'or',
+          condition: `length_mm.lte.${maxLen},length_mm.is.null`,
+          embedded: true,
+        }],
         reason: `Longueur ≤ ${maxLen} mm`,
       }
     }
 
-    // Stockage : interpréter m2_slots et sata_6gbs prudemment.
-    // m2_slots est stocké en JSONB par l'import BuildCores (objet { count, types[] })
-    // — un cast brutal en number donne NaN et fausse tout. sata_6gbs est un nombre
-    // mais peut être null si l'info est manquante. Principe : on n'exclut une
-    // famille (NVMe ou SATA) que si on est CERTAIN qu'elle est incompatible.
     case 'storage': {
-      if (!motherboard) return { filtered: false, productIds: [] }
+      if (!motherboard) return null
+      const m2Status = detectSlotPresence(motherboard.specs?.['m2_slots'])
+      const sataStatus = detectSlotPresence(motherboard.specs?.['sata_6gbs'])
 
-      const m2Raw   = motherboard.specs?.['m2_slots']
-      const sataRaw = motherboard.specs?.['sata_6gbs']
+      if (m2Status === 'unknown' || sataStatus === 'unknown') return null
+      if (m2Status === 'present' && sataStatus === 'present') return null
+      if (m2Status === 'absent' && sataStatus === 'absent') return null
 
-      const m2Status   = detectSlotPresence(m2Raw)
-      const sataStatus = detectSlotPresence(sataRaw)
-
-      // Si on ne sait pas (donnée manquante ou format inconnu) → on ne filtre pas.
-      if (m2Status === 'unknown' || sataStatus === 'unknown') {
-        return { filtered: false, productIds: [] }
-      }
-      // Les deux présents → tout compatible.
-      if (m2Status === 'present' && sataStatus === 'present') {
-        return { filtered: false, productIds: [] }
-      }
-      // Aucun des deux → mobo bizarre, on laisse passer pour ne pas bloquer.
-      if (m2Status === 'absent' && sataStatus === 'absent') {
-        return { filtered: false, productIds: [] }
-      }
-
-      // Pas de M.2 → SATA uniquement (exclure NVMe).
       if (m2Status === 'absent' && sataStatus === 'present') {
-        const { data } = await supabase
-          .from('storage_specs')
-          .select('product_id')
-          .or('nvme.eq.false,nvme.is.null')
-
         return {
-          filtered: true,
-          productIds: data?.map((r) => r.product_id) ?? [],
+          specsTable: 'storage_specs',
+          ops: [{ kind: 'or', condition: 'nvme.eq.false,nvme.is.null', embedded: true }],
           reason: 'Pas de slot M.2 — SATA uniquement',
         }
       }
-
-      // Pas de SATA → M.2 NVMe uniquement.
-      const { data } = await supabase
-        .from('storage_specs')
-        .select('product_id')
-        .or('nvme.eq.true,nvme.is.null')
-
       return {
-        filtered: true,
-        productIds: data?.map((r) => r.product_id) ?? [],
+        specsTable: 'storage_specs',
+        ops: [{ kind: 'or', condition: 'nvme.eq.true,nvme.is.null', embedded: true }],
         reason: 'Pas de port SATA — M.2 NVMe uniquement',
       }
     }
 
-    // Ventirad : socket CPU + hauteur max boîtier (si boîtier sélectionné).
     case 'cpu_cooler': {
       const socket = cpu?.specs?.['socket'] as string | undefined
-      if (!socket) return { filtered: false, productIds: [] }
-
+      if (!socket) return null
       const maxH = pcCase?.specs?.['max_cpu_cooler_height_mm'] as number | undefined
-
-      let query = supabase
-        .from('cpu_cooler_specs')
-        .select('product_id, height_mm')
-        .contains('cpu_sockets', [socket])
-
+      const ops: CompatFilterOp[] = [
+        { kind: 'contains', column: 'cpu_sockets', value: [socket], embedded: true },
+      ]
       if (maxH) {
-        query = query.or(`height_mm.lte.${maxH},height_mm.is.null`)
+        ops.push({
+          kind: 'or',
+          condition: `height_mm.lte.${maxH},height_mm.is.null`,
+          embedded: true,
+        })
       }
-
-      const { data } = await query
-      const reason = maxH ? `Socket ${socket} · hauteur ≤ ${maxH} mm` : `Socket ${socket}`
-
       return {
-        filtered: true,
-        productIds: data?.map((r) => r.product_id) ?? [],
-        reason,
+        specsTable: 'cpu_cooler_specs',
+        ops,
+        reason: maxH ? `Socket ${socket} · hauteur ≤ ${maxH} mm` : `Socket ${socket}`,
       }
     }
 
     case 'psu': {
-      const gpu = config['gpu']
       const gpuTdp = gpu?.specs?.['tdp'] as number | undefined
       const cpuTdp = cpu?.specs?.['tdp'] as number | undefined
-
-      if (!gpuTdp && !cpuTdp) return { filtered: false, productIds: [] }
-
+      if (!gpuTdp && !cpuTdp) return null
       const systemTdp = (gpuTdp ?? 0) + (cpuTdp ?? 0) + 100
       const minWattage = Math.ceil(systemTdp * 1.2)
-
-      const { data } = await supabase
-        .from('psu_specs')
-        .select('product_id')
-        .gte('wattage', minWattage)
-
       return {
-        filtered: true,
-        productIds: data?.map((r) => r.product_id) ?? [],
+        specsTable: 'psu_specs',
+        ops: [{ kind: 'gte', column: 'wattage', value: minWattage, embedded: true }],
         reason: `≥ ${minWattage}W (TDP système ~${systemTdp}W)`,
       }
     }
 
     default:
-      return { filtered: false, productIds: [] }
+      return null
+  }
+}
+
+/**
+ * @deprecated Renvoie une liste d'IDs qui dépasse la limite d'URL PostgREST
+ * quand l'usage est `.in('id', ids)`. Préférer `buildCompatibilityFilter` qui
+ * applique les contraintes côté serveur via un inner join. Conservée pour
+ * les tests existants et un éventuel usage standalone.
+ */
+export async function getCompatibleProductIds(
+  targetCategory: CategoryKey,
+  config: Partial<Record<CategoryKey, Product>>,
+): Promise<CompatibilityResult> {
+  const filter = buildCompatibilityFilter(targetCategory, config)
+  if (!filter) return { filtered: false, productIds: [] }
+
+  // On exécute directement sur la table de specs (sans préfixe), pour
+  // récupérer juste les product_id compatibles. Utilisable pour audits/tests.
+  let q = supabase.from(filter.specsTable).select('product_id') as unknown as {
+    eq: (c: string, v: unknown) => typeof q
+    contains: (c: string, v: unknown) => typeof q
+    gte: (c: string, v: unknown) => typeof q
+    or: (s: string) => typeof q
+    then: (...args: unknown[]) => Promise<{ data: Array<{ product_id: string }> | null }>
+  }
+  for (const op of filter.ops) {
+    if (op.kind === 'eq') q = q.eq(op.column, op.value)
+    else if (op.kind === 'contains') q = q.contains(op.column, op.value)
+    else if (op.kind === 'gte') q = q.gte(op.column, op.value)
+    else if (op.kind === 'or') q = q.or(op.condition)
+  }
+  const { data } = await (q as unknown as Promise<{ data: Array<{ product_id: string }> | null }>)
+  return {
+    filtered: true,
+    productIds: data?.map((r) => r.product_id) ?? [],
+    reason: filter.reason,
   }
 }

--- a/src/utils/selection-order.ts
+++ b/src/utils/selection-order.ts
@@ -47,27 +47,36 @@ export const SELECTION_ORDER: CategoryKey[] = [
 ]
 
 /**
- * Pré-requis stricts : pour pouvoir sélectionner X, ces catégories doivent
- * déjà être renseignées (faute de quoi les règles de compatibilité ne peuvent
- * pas s'appliquer correctement).
+ * Pré-requis stricts en cascade : pour sélectionner la catégorie X, TOUTES
+ * les catégories qui la précèdent dans SELECTION_ORDER doivent être renseignées.
+ * C'est un ordre fixe imposé — l'utilisateur ne peut pas sauter une étape.
+ *
+ * Conservé en plus de `missingPrereqs` pour la rétrocompatibilité avec les
+ * tests existants qui inspectent la structure des pré-requis directs.
  */
 export const PREREQS: Record<CategoryKey, CategoryKey[]> = {
   cpu: [],
   motherboard: ['cpu'],
-  pc_case: ['motherboard'],
-  ram: ['motherboard'],
-  storage: ['motherboard'],
-  gpu: [],
-  cpu_cooler: ['cpu'],
-  psu: ['cpu'],
+  pc_case: ['cpu', 'motherboard'],
+  ram: ['cpu', 'motherboard', 'pc_case'],
+  gpu: ['cpu', 'motherboard', 'pc_case', 'ram'],
+  storage: ['cpu', 'motherboard', 'pc_case', 'ram', 'gpu'],
+  cpu_cooler: ['cpu', 'motherboard', 'pc_case', 'ram', 'gpu', 'storage'],
+  psu: ['cpu', 'motherboard', 'pc_case', 'ram', 'gpu', 'storage', 'cpu_cooler'],
 }
 
-/** Pré-requis manquants pour une catégorie donnée. */
+/**
+ * Pré-requis manquants pour une catégorie donnée — tout ce qui précède dans
+ * SELECTION_ORDER et qui n'est pas encore sélectionné. L'ordre est strict :
+ * pour entrer dans la catégorie N, il faut avoir validé 0..N-1.
+ */
 export function missingPrereqs(
   category: CategoryKey,
   config: Partial<Record<CategoryKey, Product>>,
 ): CategoryKey[] {
-  return PREREQS[category].filter((p) => !config[p])
+  const idx = SELECTION_ORDER.indexOf(category)
+  if (idx <= 0) return []
+  return SELECTION_ORDER.slice(0, idx).filter((c) => !config[c])
 }
 
 /** Toutes les pré-conditions sont-elles satisfaites ? */


### PR DESCRIPTION
## Suites des soucis de filtre

Après le merge de #191, deux ajustements demandés :

### 1. Ordre strict (un seul onglet débloqué à la fois)

Avant : les onglets se débloquaient parfois en parallèle (ex : RAM et boîtier débloqués en même temps après mobo sélectionnée).

Maintenant : **PREREQS strict** — pour entrer dans la catégorie N, il faut avoir validé **toutes** les catégories 0..N-1 de SELECTION_ORDER.

\`\`\`
CPU → MOBO → BOÎTIER → RAM → GPU → STOCKAGE → VENTIRAD → PSU
 ✓     ⇒     🔒        🔒    🔒    🔒          🔒         🔒
       ✓    ⇒          🔒    🔒    🔒          🔒         🔒
              ✓        ⇒     🔒    🔒          🔒         🔒
\`\`\`

### 2. Fallback robuste quand le filtre retourne 0 produit

Symptôme rapporté : avec CPU FM2+ + mobo Mini ITX FM2+ DDR3, le boîtier, le stockage et l'alim apparaissent vides.

Cause probable : les données BuildCores sont incomplètes ou incohérentes en base (form_factor mal peuplé pour les cases anciennes, wattage null sur certaines alims, etc.). Le filtre devient trop strict et exclut tout.

**Fix** : quand le filtre de compat retourne 0 produit alors qu'un filtre est actif, on bascule en **fallback** :
- On affiche **tout le catalogue de la catégorie** (pas restreint par IDs)
- Avertissement clair en haut : *⚠️ Aucun produit ne passe le filtre X — affichage du catalogue complet. Vérifie manuellement la compatibilité.*
- L'utilisateur n'est jamais bloqué sur une liste vide.

Trade-off assumé : on accepte de potentiellement afficher des composants techniquement incompatibles, plutôt que de bloquer l'utilisateur sur une donnée manquante. Le warning explicite met la responsabilité côté user pour les cas limites.

## Tests

- 70 verts, build OK, eslint clean.
- Test de pré-requis ajusté : \`missingPrereqs('ram', {})\` retourne désormais \`['cpu', 'motherboard', 'pc_case']\` (au lieu de juste \`['motherboard']\`).

## Test plan

- [ ] Configurer un CPU AMD A10-7860K FM2+ → puis seul l'onglet MOBO est débloqué.
- [ ] Sélectionner ASRock A68M-ITX → seul l'onglet BOÎTIER est débloqué (les autres restent 🔒).
- [ ] Aller sur BOÎTIER → si la base ne contient aucun case avec \`supported_mobo_form_factors\` incluant \"Mini ITX\", le fallback s'active et tout le catalogue boîtier apparaît avec un warning.
- [ ] Aller sur STOCKAGE → idem, jamais de liste vide.
- [ ] Aller sur ALIMENTATION → si aucune alim ne passe le wattage minimum, fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)