### PR TITLE
fix(profile): corriger les contrastes (charte sombre)

### DIFF
--- a/src/components/common/Input/Input.scss
+++ b/src/components/common/Input/Input.scss
@@ -24,7 +24,7 @@
   &__label {
     font-size: $font-size-sm;
     font-weight: $font-weight-medium;
-    color: $neutral-700;
+    color: var(--text-2);
   }
 
   // -------------------------------------------------------------------------
@@ -45,19 +45,19 @@
     width: 100%;
     outline: none;
     transition: all $transition-base;
-    background-color: $white;
-    color: $neutral-900;
+    background-color: var(--surface-2);
+    color: var(--text);
     font-size: $font-size-base;
     font-family: inherit;
 
     &::placeholder {
-      color: $neutral-400;
+      color: var(--text-3);
     }
 
     &:disabled {
       opacity: 0.6;
       cursor: not-allowed;
-      background-color: $neutral-100;
+      background-color: var(--surface-3);
     }
   }
 
@@ -66,27 +66,27 @@
   // -------------------------------------------------------------------------
 
   &[data-variant="default"] .input__field {
-    border: 1px solid $neutral-200;
+    border: 1px solid var(--border-s);
     border-radius: $radius-md;
     padding: $spacing-3 $spacing-4;
   }
 
   &[data-variant="filled"] .input__field {
-    background-color: $neutral-100;
+    background-color: var(--surface-3);
     border: 1px solid transparent;
     border-radius: $radius-md;
     padding: $spacing-3 $spacing-4;
   }
 
   &[data-variant="outline"] .input__field {
-    border: 2px solid $neutral-300;
+    border: 2px solid var(--border-s);
     border-radius: $radius-md;
     padding: $spacing-3 $spacing-4;
   }
 
   &[data-variant="underline"] .input__field {
     border: none;
-    border-bottom: 2px solid $neutral-200;
+    border-bottom: 2px solid var(--border-s);
     border-radius: 0;
     padding: $spacing-3 0;
     padding-left: 0;
@@ -127,12 +127,12 @@
   &[data-focused="true"][data-variant="default"] .input__field,
   &[data-focused="true"][data-variant="filled"] .input__field,
   &[data-focused="true"][data-variant="outline"] .input__field {
-    border-color: $primary;
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+    border-color: var(--ind);
+    box-shadow: var(--shadow-focus);
   }
 
   &[data-focused="true"][data-variant="underline"] .input__field {
-    border-bottom-color: $primary;
+    border-bottom-color: var(--ind);
     box-shadow: none;
   }
 
@@ -154,7 +154,7 @@
   &[data-error="true"][data-focused="true"][data-variant="filled"] .input__field,
   &[data-error="true"][data-focused="true"][data-variant="outline"] .input__field {
     border-color: $error;
-    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
+    box-shadow: var(--shadow-focus-error);
   }
 
   // -------------------------------------------------------------------------
@@ -163,7 +163,7 @@
 
   &__icon {
     position: absolute;
-    color: $neutral-400;
+    color: var(--text-3);
     display: flex;
     align-items: center;
     pointer-events: none;
@@ -201,7 +201,7 @@
     right: $spacing-3;
     background: none;
     border: none;
-    color: $neutral-400;
+    color: var(--text-3);
     cursor: pointer;
     padding: $spacing-1;
     display: flex;
@@ -209,7 +209,7 @@
     transition: color $transition-fast;
 
     &:hover {
-      color: $neutral-700;
+      color: var(--text);
     }
   }
 
@@ -230,6 +230,6 @@
 
   &__hint {
     font-size: $font-size-xs;
-    color: $neutral-400;
+    color: var(--text-3);
   }
 }

--- a/src/pages/Profile/Profile.scss
+++ b/src/pages/Profile/Profile.scss
@@ -25,13 +25,13 @@
   &__name {
     font-size: $font-size-2xl;
     font-weight: $font-weight-bold;
-    color: $neutral-900;
+    color: var(--text);
     line-height: 1.2;
   }
 
   &__email {
     font-size: $font-size-sm;
-    color: $neutral-500;
+    color: var(--text-2);
   }
 
   &__meta {
@@ -58,7 +58,7 @@
 
   &__since {
     font-size: $font-size-xs;
-    color: $neutral-400;
+    color: var(--text-3);
   }
 
   &__header-actions {
@@ -79,13 +79,13 @@
   &__section-title {
     font-size: $font-size-xl;
     font-weight: $font-weight-semibold;
-    color: $neutral-900;
+    color: var(--text);
     margin-bottom: $spacing-1;
   }
 
   &__section-desc {
     font-size: $font-size-sm;
-    color: $neutral-500;
+    color: var(--text-2);
   }
 
   // ── Danger zone ─────────────────────────────────────────────────────────────
@@ -125,14 +125,14 @@
   &__danger-item-title {
     font-size: $font-size-base;
     font-weight: $font-weight-medium;
-    color: $neutral-900;
+    color: var(--text);
 
     .profile__danger-item--destructive & { color: $error; }
   }
 
   &__danger-item-desc {
     font-size: $font-size-sm;
-    color: $neutral-500;
+    color: var(--text-2);
     line-height: 1.5;
   }
 
@@ -146,13 +146,13 @@
 
   &__delete-modal-text {
     font-size: $font-size-sm;
-    color: $neutral-700;
+    color: var(--text-2);
     line-height: 1.6;
   }
 
   &__delete-modal-instruction {
     font-size: $font-size-sm;
-    color: $neutral-600;
+    color: var(--text-2);
     padding: $spacing-3 $spacing-4;
     background: rgba($error, 0.05);
     border-left: 3px solid $error;


### PR DESCRIPTION
Le composant Input et la page Profil utilisaient encore des tokens clairs ($white, $neutral-900/700/600/500/400) hérités d'un thème clair, d'où des champs blancs et des textes sombres illisibles sur fond sombre.

- Input: champ sur var(--surface-2)/var(--text), focus indigo (var(--shadow-focus)), icônes/toggle/clear/hint sur var(--text-3)
- Profile: titres/noms en var(--text), descriptions en var(--text-2), méta en var(--text-3), modal de suppression lisible